### PR TITLE
Опция для предзагрузки

### DIFF
--- a/src/components/settings/params.js
+++ b/src/components/settings/params.js
@@ -113,6 +113,7 @@ select('pages_save_total',{
 trigger('animation',true)
 trigger('background',true)
 trigger('torrserver_savedb',false)
+trigger('torrserver_preload', false);
 trigger('parser_use',false)
 trigger('torrserver_auth',false)
 trigger('mask',true)

--- a/src/interaction/player/video.js
+++ b/src/interaction/player/video.js
@@ -179,6 +179,7 @@ function loader(status){
  * @param {String} src 
  */
 function url(src){
+    loader(true);
     create()
 
     video.src = src

--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -187,10 +187,11 @@ function show(files){
     let playlist = []
 
     plays.forEach(element => {
-        Arrays.extend(element,{
+        Arrays.extend(element, {
             title: Utils.pathToNormalTitle(element.path),
             size: Utils.bytesToSize(element.length),
-            url: SERVER.url + '/stream?link='+SERVER.hash+'&index='+element.id+'&play'
+            url: SERVER.url + '/stream?link=' + SERVER.hash + '&index=' + element.id + '&play' +
+                (Storage.get('torrserver_preload', 'false') ? '&preload' : '')
         })
 
         playlist.push(element)

--- a/src/templates/settings/server.js
+++ b/src/templates/settings/server.js
@@ -10,6 +10,12 @@ let html = `<div>
         <div class="settings-param__value"></div>
         <div class="settings-param__descr">Торрент будет добавлен в базу TorrServer</div>
     </div>
+    
+    <div class="settings-param selector" data-type="toggle" data-name="torrserver_preload">
+        <div class="settings-param__name">Использовать буфер пред.загрузки</div>
+        <div class="settings-param__value"></div>
+        <div class="settings-param__descr">Дожидаться заполнения буфера предварительной загрузки TorrServer перед проигрыванием</div>
+    </div>
 
     <div class="settings-param-title"><span>Авторизация</span></div>
 


### PR DESCRIPTION
Добавляет в Опции\TorrServer новую настройку "Использовать буфер пред.загрузки". При включении в ссылку для проигрывания будет добавляться флаг &preload, который заставит TorrServer дожидаться заполнения буфера предварительной загрузки перед началом проигрывания. По умолчанию опция выключена.

yumata/lampa#30