### PR TITLE
Поиск по категориям в Jackett

### DIFF
--- a/src/components/torrents.js
+++ b/src/components/torrents.js
@@ -230,6 +230,7 @@ function component(object){
         u = Utils.addUrlComponent(u,'year='+encodeURIComponent((object.movie.release_date || object.movie.first_air_date || '0000').slice(0,4)))
         u = Utils.addUrlComponent(u,'is_serial='+(object.movie.first_air_date ? 'true' : 'false'))
         u = Utils.addUrlComponent(u,'genres='+encodeURIComponent(genres.join(',')))
+        u = Utils.addUrlComponent(u, 'Category[]=' + (object.movie.number_of_seasons > 0 ? 5000 : 2000)); //https://github.com/Jackett/Jackett/wiki/Jackett-Categories
 
         network.native(u,(json)=>{
             json.Results.forEach(element => {


### PR DESCRIPTION
Добавляет к урл поиска по Jackett параметр `&Category=2000` для поиска по фильмам и `&Category=5000` для поиска по сериалам, что сразу отсекает огромное количество мусора. Категории статичны для всех индексеров (https://github.com/Jackett/Jackett/wiki/Jackett-Categories)

Например, результат поиска по сериалам о Шерлоке Холмсе, было 249 результатов, стало 101.

Не работает с джек ред, потому что это не джекет.

Не понял, кстати, что за остальные параметры вставляются в урл (is_serial, year, genres, title, title_original) - я так понимаю, что джекет их никак не обрабатывает
