### PR TITLE
Настройки доступности для субтитров

### DIFF
--- a/src/components/settings/component.js
+++ b/src/components/settings/component.js
@@ -22,6 +22,10 @@ function component(name){
         comp.find('.is--player').remove()
     }
 
+    if(!Platform.is('tizen')) {
+        comp.find('.is--has_subs').remove();
+    }
+
     scrl.render().find('.scroll__content').addClass('layer--wheight').data('mheight',$('.settings__head'))
 
     comp.find('.selector').on('hover:focus',(e)=>{

--- a/src/components/settings/params.js
+++ b/src/components/settings/params.js
@@ -168,6 +168,12 @@ select('torrserver_use_link',{
     'two': 'Дополнительную'
 },'one')
 
+select('subtitles_size',{
+    'small': 'Маленькие',
+    'normal': 'Обычные',
+    'large': 'Большие',
+},'normal');
+
 
 /**
  * Добовляем тригеры
@@ -181,6 +187,8 @@ trigger('torrserver_auth',false)
 trigger('mask',true)
 trigger('playlist_next',true)
 trigger('internal_torrclient', true)
+trigger('subtitles_stroke', true);
+trigger('subtitles_backdrop', false);
 
 /**
  * Добовляем поля

--- a/src/interaction/player/video.js
+++ b/src/interaction/player/video.js
@@ -90,7 +90,19 @@ function bind(){
 
     // обновляем субтитры
     video.addEventListener('subtitle', function(e) {
-        subtitles.html(e.text)
+        //В srt существует тег {\anX}, где X - цифра от 1 до 9, Тег определяет нестандартное положение субтитра на экране.
+        //Здесь удаляется тег из строки и обрабатывается положение 8 (субтитр вверху по центру).
+        //{\an8} используется когда нужно, чтобы субтитр не перекрывал надписи в нижней части экрана или субтитры вшитые в видеоряд.
+        subtitles.removeClass('on-top');
+        const posTag = e.text.match(/^{\\an(\d)}/);
+        if(posTag) {
+            e.text = e.text.replace(/^{\\an(\d)}/, '');
+            if(posTag[1] && parseInt(posTag[1]) === 8) {
+                subtitles.addClass('on-top');
+            }
+        }
+
+        subtitles.children().html(e.text)
     })
 
     video.addEventListener('loadedmetadata', function (e) {
@@ -147,6 +159,26 @@ function subsview(status){
     subtitles.toggleClass('hide', !status)
 }
 
+/*
+* Применяет к блоку субтитров пользовательские настройки
+ */
+function applySubsSettings() {
+    const hasStroke = Storage.get('subtitles_stroke', true),
+        hasBackdrop = Storage.get('subtitles_backdrop', false),
+        size =  Storage.get('subtitles_size', 'normal');
+
+    subtitles.removeClass('has-stroke has-backdrop size--normal size--large size--small');
+    subtitles.addClass('size--' + size);
+
+    if (hasStroke) {
+        subtitles.addClass('has-stroke');
+    }
+
+    if (hasBackdrop) {
+        subtitles.addClass('has-backdrop');
+    }
+}
+
 /**
  * Создать контейнер для видео
  */
@@ -162,7 +194,9 @@ function create(){
         videobox = $('<video class="player-video__video" poster="./img/video_poster.png" crossorigin="anonymous"></video>')
 
         video = videobox[0]
-    } 
+    }
+
+    applySubsSettings();
     
     display.append(videobox)
 

--- a/src/sass/components/player/video.scss
+++ b/src/sass/components/player/video.scss
@@ -1,4 +1,5 @@
 .player-video{
+    $self: &;
     &__video{
         position: fixed;
         top: 0;
@@ -35,10 +36,44 @@
         bottom: 0;
         left: 0;
         right: 0;
-        padding: $offset;
+        margin: $offset;
         text-align: center;
         font-size: 2.5em;
-        text-shadow:  0 2px 1px #000000, 0 -2px 1px #000000, -2px 1px 0 #000000, 2px 0px 1px #000000;
+        font-weight: 600;
+        line-height: 1.25;
+
+        &.size {
+            &--large {
+                font-size: 3em;
+            }
+            &--small {
+                font-size: 2em;
+            }
+        }
+
+        &.has-backdrop {
+            #{ $self }__subtitles-text {
+                background: rgba(0, 0, 0, .5);
+            }
+        }
+
+        &.has-stroke {
+            text-shadow:  0 2px 1px #000000, 0 -2px 1px #000000, -2px 1px 0 #000000, 2px 0px 1px #000000;
+        }
+
+        &.on-top {
+            top: 0;
+        }
+    }
+
+    &__subtitles-text {
+        display: inline-block;
+        padding: .25em .5em;
+        border-radius: .25em;
+
+        &:empty {
+            display: none;
+        }
     }
 
     &.video--load{

--- a/src/templates/player/video.js
+++ b/src/templates/player/video.js
@@ -7,7 +7,9 @@ let html = `<div class="player-video">
             <rect x="13" width="6" height="25" rx="2" fill="white"/>
         </svg>
     </div>
-    <div class="player-video__subtitles hide"></div>
+    <div class="player-video__subtitles hide">
+        <div class="player-video__subtitles-text"></div>
+    </div>
 </div>`
 
 export default html

--- a/src/templates/settings/player.js
+++ b/src/templates/settings/player.js
@@ -10,6 +10,28 @@ let html = `<div>
         <div class="settings-param__value"></div>
         <div class="settings-param__descr">Автоматически переключать на следующую серию при окончание текущей</div>
     </div>
+    
+    <div class="is--has_subs">
+        <div class="settings-param-title"><span>Субтитры</span></div>
+        
+        <div class="settings-param selector" data-type="toggle" data-name="subtitles_size">
+            <div class="settings-param__name">Размер</div>
+            <div class="settings-param__value"></div>
+            <div class="settings-param__descr"></div>
+        </div>
+        
+        <div class="settings-param selector" data-type="toggle" data-name="subtitles_stroke">
+            <div class="settings-param__name">Использовать окантовку</div>
+            <div class="settings-param__value"></div>
+            <div class="settings-param__descr">Субтитры будут обведены черным цветом для улучшения читаемости</div>
+        </div>
+        
+        <div class="settings-param selector" data-type="toggle" data-name="subtitles_backdrop">
+            <div class="settings-param__name">Использовать подложку</div>
+            <div class="settings-param__value"></div>
+            <div class="settings-param__descr">Субтитры будут отображаться на полупрозрачной подложке для улучшения читаемости</div>
+        </div>
+    </div>  
 </div>`
 
 export default html


### PR DESCRIPTION
Добавлены новые настройки субтитров в раздел плеер:
- Размер субтитров (маленькие, **нормальные**, большие) - попытка 2 :)
- Использовать окантовку (**вкл**, выкл) - включает обводку субтитров
- Использовать подложку (вкл, **выкл**) - включает черную полупрозрачную подложку под субтитрами

Новые опции отображаются только на тизенах т.к. только там на текущий момент используются субтитры внутри плеера. (Если я, конечно, не ошибаюсь. Если ошибаюсь, то поменяйте как надо)

Также добавлена обработка тега {/anX} в субтитрах. Этот тег в начале строки означает, что строка должна располагаться в одной из 9 позиций на экране. Тег удаляется из строки перед выводом, для 8 позиции сделан корректный вывод строки сверху по центру, остальные позиции игнорируются т.к. используются редко, да и не нужны. {/an8} испольуется для того, чтобы субтитры не перекрывали другие надписи внизу экрана (например, субтитры вшитые в видеоряд или титры)

Субтитры с подложкой:
![Субтитры с подложкой](https://i.imgur.com/qawjZfK.jpg)