### PR TITLE
use path in stream url (as TorrServer Client)

### DIFF
--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -220,7 +220,7 @@ function list(items, params){
             episode: info.episode,
             title: Utils.pathToNormalTitle(element.path),
             size: Utils.bytesToSize(element.length),
-            url: Torserver.stream(SERVER.hash, element.id),
+            url: Torserver.stream(encodeURIComponent(element.path.split('\\').pop().split('/').pop()), SERVER.hash, element.id),
             timeline: view,
             air_date: '--',
             img: './img/img_broken.svg',

--- a/src/interaction/torserver.js
+++ b/src/interaction/torserver.js
@@ -91,8 +91,8 @@ function connected(success, fail){
     },JSON.stringify({action: 'get'}))
 }
 
-function stream(hash, id){
-    return url() + '/stream?link=' + hash + '&index=' + id + '&play'
+function stream(path, hash, id){
+    return url() + '/stream/'+ path +'?link=' + hash + '&index=' + id + '&play'
 }
 
 function drop(hash, success, fail){


### PR DESCRIPTION
Генерируется ссылка на просмотр как в Андроид клиенте TorrServe
На андроиде это помогает работать функции воспроизведения с места остановки в плеере ViMu