### PR TITLE
Tracks.js: Замена сеттера субтитров

### DIFF
--- a/plugins/tracks/tracks.js
+++ b/plugins/tracks/tracks.js
@@ -101,7 +101,7 @@ function subscribe(data){
 
                 console.log('Tracks','subs original', orig)
 
-                Object.defineProperty(elem, "enabled", {
+                Object.defineProperty(elem, "mode", {
                     set: (v)=>{
                         if(v){
                             let txt = getSubs()


### PR DESCRIPTION
У объекта субтитров нет св-ва `enabled` поэтому код в этом сеттере никогда не будет выполнен, что ломает переключение сабов. Заменил на `mode` по аналогии с реализацией переключения сабов на вебос.