### PR TITLE
Trust users in choice of protocol

### DIFF
--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -168,8 +168,8 @@ function strToTime(str){
 
 function checkHttp(url){
     url = url + ''
-    url = url.replace(/https:\/\//,'')
-    url = url.replace(/http:\/\//,'')
+
+    if (url.indexOf("http://") == 0 || url.indexOf("https://") == 0) return url; 
 
     url = protocol() + url
 


### PR DESCRIPTION
Я тут столкнулся с невозможностью работы лампы с https адресами, домены которых внесены в hsts preload список (ака этим доменам нельзя работать по http).
Небольшое расследование привело к этому фрагменту кода, который вырезает указанный пользователем протокол и насильно вставляет `http://`. Давайте не будем считать пользователей совсем уж идиотами, и если сказано https - то пущай лампа ходит по https :)