### PR TITLE
Add electron detection, treating the same as for NW.js

### DIFF
--- a/src/components/settings/component.js
+++ b/src/components/settings/component.js
@@ -40,7 +40,7 @@ function Component(name, component_params = {}){
             comp.find('.is--player').remove()
         }
 
-        if(!Platform.is('nw')){
+        if(!Platform.desktop()){
             comp.find('.is--nw').remove()
         }
 

--- a/src/components/settings/params.js
+++ b/src/components/settings/params.js
@@ -41,7 +41,7 @@ function init(){
 
         trigger('internal_torrclient', false)
     }
-    else if(Platform.is('nw')){
+    else if(Platform.desktop()){
         select('player',{
             'inner': '#{settings_param_player_inner}',
             'other': '#{settings_param_player_outside}',

--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -651,7 +651,7 @@ function play(data){
 
         Android.openPlayer(data.url, data)
     }
-    else if(Platform.is('nw') && Storage.field('player') == 'other'){
+    else if(Platform.desktop() && Storage.field('player') == 'other'){
         let path = Storage.field('player_nw_path')
         let file = require('fs')
 

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -25,6 +25,9 @@ function init(){
     else if(typeof nw !== 'undefined') {
         Storage.set('platform', 'nw')
     }
+    else if(navigator.userAgent.toLowerCase().indexOf("electron") > -1) {
+        Storage.set('platform', 'electron')
+    }
     else if(navigator.userAgent.toLowerCase().indexOf("netcast") > -1) {
         Storage.set('platform', 'netcast')
     }
@@ -63,7 +66,7 @@ function is(need){
  * @returns Boolean
  */
 function any(){
-    return is('tizen') || is('webos') || is('android') || is('nw') || is('netcast') ? true : false
+    return is('tizen') || is('webos') || is('android') || is('netcast') || desktop() ? true : false
 }
 
 /**
@@ -74,14 +77,20 @@ function tv(){
     return is('tizen') || is('webos') || is('orsay') || is('netcast') ? true : false
 }
 
+/**
+ * Если это NW.js или Electron
+ * @returns Boolean
+ */
+function desktop() {
+    return is('nw') || is('electron')
+}
+
 function version(name){
-    if(name){
+    if (name == 'app') {
         return Manifest.app_version
-    }
-    else if(name){
+    } else if (name == 'android') {
         return AndroidJS.appVersion()
-    }
-    else{
+    } else {
         return ''
     }
 }
@@ -92,5 +101,6 @@ export default {
     any,
     is,
     tv,
+    desktop,
     version
 }


### PR DESCRIPTION
Я тут делаю сборку лампы аналогичную NW.js, но только на электроне, понадобилось вот детектить электрон в самой лампе и делать аналогичные для NW.js действия.

И ещё вопросик, интересно ли увидеть поддержку электрона в самой репе лампы? Он очень хорошо ложится на исходники лампы и позволяет паковать десктопные сборки для всех трёх основных осей (windows, linux, macos).