### PR TITLE
Episodes Parser introduced + vitest for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "gulp",
-    "debug": "gulp debug"
+    "debug": "gulp debug",
+    "test": "vitest"
   },
   "author": "unk",
   "license": "ISC",
@@ -14,7 +15,8 @@
     "chokidar": "^3.5.2",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
-    "gulp-newer": "^1.4.0"
+    "gulp-newer": "^1.4.0",
+    "vitest": "^0.32.2"
   },
   "dependencies": {
     "@babel/core": "^7.15.8",
@@ -34,6 +36,7 @@
     "rollup-plugin-regenerator": "^0.6.0",
     "rollup-plugin-web-worker-loader": "^1.6.1",
     "sass": "^1.42.1",
+    "subsrt": "^1.1.1",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   }

--- a/spec/episodes_parser.spec.js
+++ b/spec/episodes_parser.spec.js
@@ -1,0 +1,30 @@
+import parse from '../src/interaction/episodes_parser'
+
+import {expect, suite, test} from 'vitest'
+
+function parseTitle(title, singleMovie) {
+    const movie = singleMovie ? {} : {number_of_seasons: 1}
+    return parse.parse(title, movie, true)
+}
+
+function testTitle(title, season, episode) {
+    test(title, () => {
+        const result = parseTitle(title, episode === 0)
+        expect(result.season, "Season").toBe(season);
+        expect(result.episode, "Episode").toBe(episode);
+    })
+}
+
+suite('Title tests', () => {
+    testTitle('Anime Name - Studio.Name [WEBRip 1080p HEVC]/Anime_Name_[01]_[Studio.Name]_[WEBRip_1080p_HEVC].mkv', 1, 1)
+    testTitle('Anime Name - Studio.Name [WEBRip 1080p HEVC]/Anime_Name_[05]_[Studio.Name]_[WEBRip_1080p_HEVC].mkv', 1, 5)
+    testTitle('The.SerialName.2023.S03.1080p.NF.WEB-DL.DDP5.1.x264/The.SerialName.2023.S03.EP01.1080p.WEB-DL.DDP5.1.x264.mkv', 3, 1)
+    testTitle('The.SerialName.2023.S05.1080p.NF.WEB-DL.DDP5.1.x264/The.SerialName.2023.S05.EP03.1080p.WEB-DL.DDP5.1.x264.mkv', 5, 3)
+    testTitle('Movie.Name.2023.1080p.AMZN_от Studio.Name.mkv', 0, 0)
+    testTitle('SerialName.S01.1080p.WEB-DL.DDP5.1.H.264/SerialName.S01E04.EpisodeName.1080p.WEB-DL.DDP5.1.H.264.mkv', 1, 4)
+    testTitle('SerialName.2023.S02.WEB-DL.1080p.STUDIO.NAME/SerialName.2023.S02E05.WEB-DL.1080p.STUDIO.NAME.mkv', 2, 5)
+    testTitle('Long Serial Name, Without Episodes - 01.mkv', 1, 1)
+    testTitle('Long Serial Name, Without Episodes - 06.mkv', 1, 6)
+    testTitle('Anime Name [TV-1] [2021] [AT-X] [1080p] [RUS + JAP]/Anime Name - 05 (AT-X 1920x1080 x265 AAC Rus + Jap).mkv', 1, 5)
+    testTitle('Anime.Name.S03.1080p.Studio.Name/Anime.Name.S03E06.mp4', 3, 6)
+})

--- a/src/interaction/episodes_parser.js
+++ b/src/interaction/episodes_parser.js
@@ -1,0 +1,55 @@
+// import Utils from "../utils/math.js";
+
+function parse(file_path, movie, is_file){
+    let data = {
+        hash_string: '',
+        season: movie.number_of_seasons ? 1 : 0,
+        episode: 0,
+        serial: !!movie.number_of_seasons
+    }
+
+    const regexps = [
+        /s(?<season>[0-9]+)\.?ep?(?<episode>[0-9]+)/i,
+        /s(?<season>[0-9]{2})(?<episode>[0-9]+)/i,
+        /[ |\[(](?<season>[0-9]{1,2})x(?<episode>[0-9]+)/i,
+        /[ |\[(](?<season>[0-9]{1,3}) of (?<episode>[0-9]+)/i,
+        /ep?(?<episode>[0-9]+)/i,
+        / 0(?<episode>[0-9]+)/i,
+        /\[(?<episode>[0-9]+)]/i,
+
+    ]
+
+    let match = undefined
+
+    regexps.find((regexp)=> {
+        match = file_path.match(regexp)
+        return match !== null
+    })
+
+    if (match && match.groups && match.groups.season)
+        data.season  = parseInt(match.groups.season)
+
+    if (match && match.groups && match.groups.episode) {
+        if (movie.number_of_seasons && data.season === 0)
+            data.season = 1;
+        data.episode = parseInt(match.groups.episode)
+    }
+
+    if (!is_file) {
+        if (movie.number_of_seasons) {
+            data.hash_string = [data.season, data.episode, movie.original_title].join('')
+        } else if (movie.original_title && !data.serial) {
+            data.hash_string = movie.original_title
+        } else {
+            data.hash_string = file_path
+        }
+    } else {
+        data.hash_string = file_path
+    }
+
+    return data
+}
+
+export default {
+    parse
+}

--- a/src/interaction/torserver.js
+++ b/src/interaction/torserver.js
@@ -1,12 +1,13 @@
 import Storage from '../utils/storage'
 import Utils from '../utils/math'
-import Reguest from '../utils/reguest'
+import Request from '../utils/reguest'
 import Template from './template'
 import Controller from './controller'
 import Modal from './modal'
 import Lang from '../utils/lang'
+import EpisodeParser from './episodes_parser'
 
-let network = new Reguest()
+let network = new Request()
 
 function url(){
     let u = ip()
@@ -133,72 +134,8 @@ function remove(hash, success, fail){
 }
 
 function parse(file_path, movie, is_file){
-    let path = file_path.toLowerCase()
-    let data = {
-        hash: '',
-        season: 0,
-        episode: 0,
-        serial: movie.number_of_seasons ? true : false
-    }
-
-    let math = path.match(/s([0-9]+)\.?ep?([0-9]+)/)
-
-    if(!math) math = path.match(/s([0-9]{2})([0-9]+)/)
-    if(!math) math = path.match(/[ |\[|(]([0-9]{1,2})x([0-9]+)/)
-    if(!math){
-        math = path.match(/[ |\[|(]([0-9]{1,3}) of ([0-9]+)/)
-
-        if(math)  math = [0,1,math[1]]
-    } 
-
-    if(!math){
-        math = path.match(/ep?([0-9]+)/)
-
-        if(math) math = [0,0,math[1]]
-    }
-
-    if(is_file){
-        data.hash = Utils.hash(file_path)
-    }
-    else if(math && movie.number_of_seasons){
-        
-        data.season  = parseInt(math[1])
-        data.episode = parseInt(math[2])
-        
-        if(data.season === 0){
-            math = path.match(/s([0-9]+)/)
-
-            if(math) data.season = parseInt(math[1])
-        }
-
-        if(data.episode === 0){
-            math = path.match(/ep?([0-9]+)/)
-
-            if(math) data.episode = parseInt(math[1])
-        }
-
-        if(isNaN(data.season))  data.season  = 0
-        if(isNaN(data.episode)) data.episode = 0
-
-        if(data.season && data.episode){
-            data.hash = Utils.hash([data.season, data.episode, movie.original_title].join(''))
-        }
-        else if(data.episode){
-            data.season = 1
-
-            data.hash = Utils.hash([data.season, data.episode, movie.original_title].join(''))
-        }
-        else{
-            hash = Utils.hash(file_path)
-        }
-    } 
-    else if(movie.original_title && !data.serial){
-        data.hash = Utils.hash(movie.original_title)
-    }
-    else{
-        data.hash = Utils.hash(file_path)
-    }
-
+    const data = EpisodeParser.parse(file_path, movie, is_file)
+    data.hash = Utils.hash(data.hash_string)
     return data
 }
 


### PR DESCRIPTION
Добрый день, 

В этом PR я попытался улучшить отображение списка эпизодов для торрентов, где название эпизодов добавлено в формате `[01]`. 

Чтобы не сломать текущее поведение (т.к. код парсинга был переписан), я добавил тесты на vitest.
Проблема, с которой я столкнулся - это то, что в текущем коде парсинг эпизодов сильно завязан на код хеширования, из-за чего тестам было необходимо подтянуть все зависимости вплоть до работы с DOM, что для тестов нужно было нетривиально мокать.

В итоге я разделил парсинг эпизодов и хеширование.

Ниже "примеры" отображения списка эпизодов (на выборе файлов и в плейлисте) до:
![изображение](https://github.com/yumata/lampa-source/assets/194469/79e202e6-16e5-4cc8-b324-61835288508a)
![изображение](https://github.com/yumata/lampa-source/assets/194469/97f48664-a1aa-4af3-9a94-461c2287537d)

После:
![изображение](https://github.com/yumata/lampa-source/assets/194469/ab5ae833-3690-42fa-9529-85b9abfc8236)
![изображение](https://github.com/yumata/lampa-source/assets/194469/df20509c-54bb-4305-ace2-f3cf540a7f13)

Возможно я упустил какие-то варианты именования файлов, готов добавить в тесты и регулярные выражения.

Заранее спасибо за крутое приложение.
