### PR TITLE
Update tracks.js

### DIFF
--- a/plugins/tracks/tracks.js
+++ b/plugins/tracks/tracks.js
@@ -330,9 +330,17 @@ function parseMetainfo(data){
                 let line = {}
 
                 if(v.width && v.height) line.video = v.width + 'х' + v.height
+			    if (v.tags){
+				    if (v.tags.DURATION){
+					    line.duration = v.tags.DURATION.split(".")
+					    line.duration.pop()
+					}	
+				}                
                 if(v.codec_name)        line.codec = v.codec_name.toUpperCase()
                 if(Boolean(v.is_avc))   line.avc = 'AVC'
-
+                let bit = v.bit_rate ? v.bit_rate : v.tags && (v.tags.BPS || v.tags["BPS-eng"]) ? v.tags.BPS || v.tags["BPS-eng"] : '--'
+                line.rate = bit == '--' ? bit : Math.round(bit/1000000) + ' ' + Lampa.Lang.translate('speed_mb')
+                
                 if(Lampa.Arrays.getKeys(line).length) video.push(line)
             })
 
@@ -346,7 +354,7 @@ function parseMetainfo(data){
                 line.name = a.tags ? (a.tags.title || a.tags.handler_name) : ''
 
                 if(a.codec_name) line.codec = a.codec_name.toUpperCase()
-                if(a.channel_layout) line.channels = a.channel_layout.replace('(side)','').replace('stereo','2.0')
+                if(a.channel_layout) line.channels = a.channel_layout.replace('(side)','').replace('stereo','2.0').replace('8 channels (FL+FR+FC+LFE+SL+SR+TFL+TFR)','7.1')
 
                 let bit = a.bit_rate ? a.bit_rate : a.tags && (a.tags.BPS || a.tags["BPS-eng"]) ? a.tags.BPS || a.tags["BPS-eng"] : '--'
 


### PR DESCRIPTION
при наличии тегов добавляет длительность и битрейт видеопотока
![image](https://github.com/yumata/lampa-source/assets/84480313/c01844c5-62e1-4818-95cf-40b8be044a28)
прячет ненужную инфу для 7.1 дорожек
![image](https://github.com/yumata/lampa-source/assets/84480313/f7b64584-2854-48a3-a416-21ab668b389e)
