### PR TITLE
Добавил тип парсера для торрентов TorrServer

### DIFF
--- a/src/components/settings/params.js
+++ b/src/components/settings/params.js
@@ -433,7 +433,8 @@ select('poster_size',{
 
 select('parser_torrent_type',{
     'jackett': 'Jackett',
-    'prowlarr': 'Prowlarr'
+    'prowlarr': 'Prowlarr',
+    'torrserver': 'TorrServer'
 },'jackett')
 
 select('jackett_interview',{


### PR DESCRIPTION
Добавил тип парсера для торрентов TorrServer
Все настройки тянутся из пункта настроек TorrServer
Чтобы работало в настройках TorrServer нужно включить поиск по RuTor

Данных о торрентах он предоставляет не много, но настроить его проще чем другое варианты

<details>
  <summary>Данные от сервера</summary>
<pre>
[
  {
    "audioQuality": 0,
    "categories": "string",
    "createDate": "string",
    "hash": "string",
    "imdbid": "string",
    "link": "string",
    "magnet": "string",
    "name": "string",
    "names": [
      "string"
    ],
    "peer": 0,
    "seed": 0,
    "size": "string",
    "title": "string",
    "tracker": "string",
    "videoQuality": 0,
    "year": 0
  }
]
</pre>
</details>