### PR TITLE
tracks for mp4 files

### DIFF
--- a/plugins/tracks/tracks.js
+++ b/plugins/tracks/tracks.js
@@ -4,7 +4,7 @@ let list_opened   = false
 let logs          = true
 
 function reguest(params, callback){
-    if(params.ffprobe){
+    if(params.ffprobe && !params.path.endsWith(".mp4")){
         setTimeout(()=>{
             callback({streams: params.ffprobe})
         },200)


### PR DESCRIPTION
Parser's ffprobe does not handle mp4 container properly. Read tags from external source for mp4.