### PR TITLE
Add hover event switcher

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -95,6 +95,7 @@ import Sound from './utils/sound'
 import AppStatus from './interaction/status'
 import Iptv from './utils/iptv'
 import Bell from './interaction/bell'
+import HoverSwitcher from './interaction/hover_switcher'
 
 /**
  * Настройки движка
@@ -317,6 +318,8 @@ function prepareApp(){
     Storage.init()
 
     AppStatus.push('Storage init')
+
+    HoverSwitcher.init()
 
     /** Передаем фокус в контроллер */
 

--- a/src/interaction/hover_switcher.js
+++ b/src/interaction/hover_switcher.js
@@ -8,7 +8,7 @@ function init() {
   // Disable hover on any keyboard event
   document.addEventListener("keydown", () => {
     if (!isKeyboardMode) {
-        console.info("Keyboard moved, disabling pointer events");
+      console.debug("Keyboard moved, disabling pointer events");
       isKeyboardMode = true;
       document.head.appendChild(noHoverStyle);
     }
@@ -17,7 +17,7 @@ function init() {
   // Re-enable hover on mouse movement
   document.addEventListener("mousemove", () => {
     if (isKeyboardMode) {
-      console.info("Mouse moved, enabling pointer events");
+      console.debug("Mouse moved, enabling pointer events");
       isKeyboardMode = false;
       document.head.removeChild(noHoverStyle);
     }

--- a/src/interaction/hover_switcher.js
+++ b/src/interaction/hover_switcher.js
@@ -1,0 +1,29 @@
+// Style to disable hover effects
+const noHoverStyle = document.createElement("style");
+noHoverStyle.innerHTML = "* { pointer-events: none !important; }";
+
+let isKeyboardMode = false;
+
+function init() {
+  // Disable hover on any keyboard event
+  document.addEventListener("keydown", () => {
+    if (!isKeyboardMode) {
+        console.info("Keyboard moved, disabling pointer events");
+      isKeyboardMode = true;
+      document.head.appendChild(noHoverStyle);
+    }
+  });
+
+  // Re-enable hover on mouse movement
+  document.addEventListener("mousemove", () => {
+    if (isKeyboardMode) {
+      console.info("Mouse moved, enabling pointer events");
+      isKeyboardMode = false;
+      document.head.removeChild(noHoverStyle);
+    }
+  });
+}
+
+export default {
+  init,
+};


### PR DESCRIPTION
To prevent conflicting hovers from both keyboard and mouse

Didn't observe this шт Safari, but in Arc (Chrome based) on MacOS there's a conflict between hovers from mouse and the keyboard when using a remote+mouse input type

Keyboard presses are on the bottom left corner of the recording. Tested in Safari macOS -> no negative side effects

No switcher

https://github.com/user-attachments/assets/739c7d92-18ca-42f3-b3b1-7e1d7ed269a8

With a switcher

https://github.com/user-attachments/assets/b3f994c3-87f8-4530-956d-4fdfda279bbd

