### PR TITLE
Allow for more logging levels and add brackets to devtools logs

### DIFF
--- a/src/interaction/console.js
+++ b/src/interaction/console.js
@@ -217,7 +217,7 @@ function decode(arr){
 }
 
 function follow(){
-  const _get_logger_function = function (func, color, prefix='') { 
+  const _get_logger_function = function (func, color, prefix='') {
         return function() {
             let msgs = [];
             let mcon = [];
@@ -235,16 +235,19 @@ function follow(){
                 name = 'Other'
             }
             else{
+                // Add color and prefix to lampa console
                 let spanColor = color || Utils.stringToHslColor(msgs[0], 50, 65)
                 prefix = prefix ? ' ' + prefix : ''
                 msgs[0] = '<span style="color: '+spanColor+'">' + msgs[0] + prefix + '</span>'
+
+                // Add brackets to real log
+                if (mcon.length > 0) {
+                    mcon[0] = '[' + mcon[0] + ']'
+                }
             }
 
             add(name,msgs.join(' '))
 
-            if (mcon.length > 0) {
-                mcon[0] = '[' + mcon[0] + ']'
-            }
             func.apply(console,mcon)
         }
     }

--- a/src/interaction/console.js
+++ b/src/interaction/console.js
@@ -217,32 +217,41 @@ function decode(arr){
 }
 
 function follow(){
-    let log = console.log
+  const _get_logger_function = function (func, color, prefix='') { 
+        return function() {
+            let msgs = [];
+            let mcon = [];
 
-    console.log = function(){
-        let msgs = [];
-        let mcon = [];
+            while(arguments.length) {
+                let arr = [].shift.call(arguments)
 
-        while(arguments.length) {
-            let arr = [].shift.call(arguments)
+                msgs.push(decode(arr))
+                mcon.push(arr)
+            }
 
-            msgs.push(decode(arr))
-            mcon.push(arr)
+            let name = msgs[0]
+
+            if(msgs.length < 2){
+                name = 'Other'
+            }
+            else{
+                let spanColor = color || Utils.stringToHslColor(msgs[0], 50, 65)
+                prefix = prefix ? ' ' + prefix : ''
+                msgs[0] = '<span style="color: '+spanColor+'">' + msgs[0] + prefix + '</span>'
+            }
+
+            add(name,msgs.join(' '))
+
+            if (mcon.length > 0) {
+                mcon[0] = '[' + mcon[0] + ']'
+            }
+            func.apply(console,mcon)
         }
-
-        let name = msgs[0]
-
-        if(msgs.length < 2){
-            name = 'Other'
-        }
-        else{
-            msgs[0] = '<span style="color: '+Utils.stringToHslColor(msgs[0], 50, 65)+'">' + msgs[0] + '</span>'
-        }
-
-        add(name,msgs.join(' '))
-
-        log.apply(console,mcon)
     }
+
+    console.log = _get_logger_function(console.log, null)
+    console.error = _get_logger_function(console.error, 'red', 'ERROR')
+    console.warn = _get_logger_function(console.warn, 'yellow', 'WARNING')
     
     window.addEventListener("error", function (e) {
         let welcome = $('.welcome')


### PR DESCRIPTION
Adding brackets to devtools logs provides better visibility and an ability to quickly filter out real lampa/extensions logs. Also allowing for more log levels to end up in the console will provide more data to quickly see what went wrong

<img width="296" alt="image" src="https://github.com/user-attachments/assets/7699b925-14c5-4521-97e5-ab726c60e269" />

<img width="251" alt="image" src="https://github.com/user-attachments/assets/d343e65b-f154-4dd2-aed9-2380a542cd1a" />
