### PR TITLE
Optically align play icon by adjusting svg viewbox

### DIFF
--- a/src/templates/player/panel.js
+++ b/src/templates/player/panel.js
@@ -69,8 +69,8 @@ let html = `<div class="player-panel">
                 </div>
                 <div class="player-panel__playpause button selector">
                     <div>
-                        <svg width="22" height="25" viewBox="0 0 22 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M21 10.7679C22.3333 11.5377 22.3333 13.4622 21 14.232L3.75 24.1913C2.41666 24.9611 0.75 23.9989 0.75 22.4593L0.750001 2.5407C0.750001 1.0011 2.41667 0.0388526 3.75 0.808653L21 10.7679Z" fill="currentColor"/>
+                        <svg width="22" height="25" viewBox="-3 0 25 25" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M21 10.768c1.333 0.77 1.333 2.694 0 3.464l-17.25 9.96c-1.333 0.77 -3 -0.193 -3 -1.733V2.541C0.75 1 2.417 0.039 3.75 0.809z"/>
                         </svg>
                     </div>
                     <div>


### PR DESCRIPTION
Another way to fix #238 and keep it responsible.

Before:
![before](https://github.com/user-attachments/assets/4bbe62a2-3902-41d5-b33e-2c9e03814096)

After:
![after](https://github.com/user-attachments/assets/b5848f64-a490-4211-bb12-8ae4d4d731eb)

Возможно, нужно поменять и в других местах:
https://github.com/yumata/lampa-source/blob/f39af6bd47cb674b432b14308ecb98fce446693d/public/img/icons/player/play.svg#L1

https://github.com/yumata/lampa-source/blob/f39af6bd47cb674b432b14308ecb98fce446693d/plugins/record/record.js#L124