### PR TITLE
Fix text overflow of the extension title

### DIFF
--- a/src/sass/components/extensions.scss
+++ b/src/sass/components/extensions.scss
@@ -89,6 +89,8 @@
         &-name{
             font-size: 1.1em;
             margin-bottom: 0.8em;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
         &-descr{
             line-height: 1.5;


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/0c726e48-6d7e-4120-a1fe-759f2ad1d8c5)

After:
![after](https://github.com/user-attachments/assets/27ace773-e89c-43dc-9fec-ab38e450036e)
