### PR TITLE
refactor: remove AppleTV torrents gating condition

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -138,7 +138,6 @@ if(typeof window.lampa_settings == 'undefined'){
 let torrents_use = true
 let agent        = navigator.userAgent.toLowerCase()
 let conditions   = [
-    agent.indexOf("ipad") > -1 && window.innerWidth == 1920 && window.innerHeight == 1080,
     agent.indexOf("lampa_client_yasha") > -1,
     typeof AndroidJS !== 'undefined' && (AndroidJS.appVersion() + '').toLowerCase().indexOf('rustore') > -1 && !localStorage.getItem('parser_use')
 ]


### PR DESCRIPTION
This PR contains commit `278427db20baf3c04902502cf329381b1cce024d`.

Summary:
- removed AppleTV (`ipad + 1920x1080`) condition from `torrents_use` gating
- kept the remaining moderation-related conditions unchanged