### PR TITLE
Global search for jackett/prowlarr

### DIFF
--- a/public/lang/be.js
+++ b/public/lang/be.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Ідзе пошук...',
     search_start: 'Пачаць пошук',
     search_nofound: 'Па вашым запыце нічога не знойдзена.',
+	global_search: 'Сусветны пошук',
 
     full_genre: 'Жанр',
     full_production: 'Вытворчасць',

--- a/public/lang/bg.js
+++ b/public/lang/bg.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Търсенето е в ход...',
     search_start: 'За да започнете търсене',
     search_nofound: 'Нищо не беше намерено според вашата заявка.',
+	global_search: 'Глобално търсене',
 
     full_genre: 'Жанр',
     full_production: 'Продукция',

--- a/public/lang/cs.js
+++ b/public/lang/cs.js
@@ -26,6 +26,7 @@ export default {
     search_searching: "Probíhá hledání...",
     search_start: "Začít hledat",
     search_nofound: "Podle vašeho dotazu nebylo nic nalezeno.",
+	global_search: 'Globální vyhledávání',
 
     full_genre: "Žánr",
     full_production: "Produkce",

--- a/public/lang/en.js
+++ b/public/lang/en.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Search in progress...',
     search_start: 'To start searching',
     search_nofound: 'Nothing was found according to your request.',
+	global_search: 'Global search',
 
     full_genre: 'Genre',
     full_production: 'Production',

--- a/public/lang/fr.js
+++ b/public/lang/fr.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Recherche en cours...',
     search_start: 'Pour commencer la recherche',
     search_nofound: 'Aucun résultat ne correspond à votre requête.',
+	global_search: 'Recherche globale',
 
     full_genre: 'Genre',
     full_production: 'Production',

--- a/public/lang/he.js
+++ b/public/lang/he.js
@@ -23,6 +23,7 @@ export default {
     search_searching: 'חיפוש בתהליך...',
     search_start: 'להתחיל לחפש',
     search_nofound: 'שום דבר לא נמצא לפי בקשתך',
+	global_search: 'חיפוש כללי',
     full_genre: 'סגנון',
     full_production: 'הפקה',
     full_date_of_release: 'תאריך השקה',

--- a/public/lang/pt.js
+++ b/public/lang/pt.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Procura em progresso...',
     search_start: 'Começar a pesquisar',
     search_nofound: 'Não encontrámos nada relacionado com a sua pesquisa.',
+	global_search: 'Pesquisa global',
 
     full_genre: 'Gênero',
     full_production: 'Produção',

--- a/public/lang/ro.js
+++ b/public/lang/ro.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Căutare în curs...',
     search_start: 'Pentru a începe căutarea',
     search_nofound: 'Nu s-a găsit nimic conform solicitării tale.',
+	global_search: 'Căutare globală',
 
     full_genre: 'Gen',
     full_production: 'Producție',

--- a/public/lang/ru.js
+++ b/public/lang/ru.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Идет поиск...',
     search_start: 'Начать поиск',
     search_nofound: 'По вашему запросу ничего не найдено.',
+	global_search: 'Глобальный поиск',
 
     full_genre: 'Жанр',
     full_production: 'Производство',

--- a/public/lang/uk.js
+++ b/public/lang/uk.js
@@ -24,6 +24,7 @@ export default {
     search_searching: 'Йде пошук...',
     search_start: 'Розпочати пошук',
     search_nofound: 'На ваш запит нічого не знайдено.',
+	global_search: 'Глобальний пошук',
     full_genre: 'Жанр',
     full_production: 'Виробництво',
     full_date_of_release: 'Дата релізу',

--- a/public/lang/zh.js
+++ b/public/lang/zh.js
@@ -24,6 +24,7 @@ export default {
     search_searching: '搜索中...',
     search_start: '开始搜索',
     search_nofound: '根据您的要求没有找到相关内容。',
+	global_search: '全局搜索',
     full_genre: '类型',
     full_production: '出品公司',
     full_date_of_release: '发布日期',

--- a/src/components/torrents.js
+++ b/src/components/torrents.js
@@ -166,10 +166,11 @@ function component(object){
             this.empty(Lang.translate('torrent_error_connect') + ': ' + text)
         })
 
-        filter.onSearch = (value)=>{
+        filter.onSearch = (value, extra = {})=>{
             Activity.replace({
                 search: value,
-                clarification: true
+                clarification: true,
+				global: extra.global
             })
         }
 

--- a/src/core/api/sources/parser.js
+++ b/src/core/api/sources/parser.js
@@ -299,7 +299,7 @@ function jackett(params = {}, base_url, api_key, source_rank, oncomplite, onerro
         u = Utils.addUrlComponent(u,'year='+encodeURIComponent(((params.movie.first_air_date || params.movie.release_date || '0000') + '').slice(0,4)))
         u = Utils.addUrlComponent(u,'is_serial='+(params.movie.original_name ? '2' : params.other ? '0' : '1'))
         u = Utils.addUrlComponent(u,'genres='+encodeURIComponent(genres.join(',')))
-        u = Utils.addUrlComponent(u, 'Category[]=' + (params.movie.number_of_seasons > 0 ? 5000 : 2000) + (params.movie.original_language == 'ja' ? ',5070' : ''))
+        if(!params.global) u = Utils.addUrlComponent(u, 'Category[]=' + (params.movie.number_of_seasons > 0 ? 5000 : 2000) + (params.movie.original_language == 'ja' ? ',5070' : ''))
     }
 
     network.native(u,(json)=>{
@@ -333,11 +333,11 @@ function prowlarr(params = {}, base_url, api_key, source_rank, oncomplite, onerr
     if(!params.from_search){
         const isSerial = !!(params.movie.original_name);
 
-        if (params.movie.number_of_seasons > 0) {
-            q.push({name: 'categories', value: '5000'})
-        }
-        if (params.movie.original_language == 'ja') {
-            q.push({name: 'categories', value: '5070'})
+        if(!params.global){
+            q.push({
+                name: 'categories',
+                value: (params.movie.number_of_seasons > 0 ? '5000' : '2000') + (params.movie.original_language == 'ja' ? ',5070' : '')
+            })
         }
         q.push({name: 'type', value: isSerial ? 'tvsearch' : 'search'})
     }

--- a/src/interaction/filter.js
+++ b/src/interaction/filter.js
@@ -39,6 +39,11 @@ function Filter(params = {}){
             title: Lang.translate('filter_set_name'),
             query: ''
         })
+		
+		search.push({
+            title: Lang.translate('global_search'),
+            global_search: true
+        })
 
         if(earlier){
             search.push({
@@ -138,6 +143,19 @@ function Filter(params = {}){
             items: search,
             onBack: this.onBack,
             onSelect: (a)=>{
+				if(a.global_search){
+                     new Search({
+                         input: params.search || '',
+                         onSearch: (new_query)=>{
+                            this.onSearch(new_query, {
+                                global: true
+                            })
+                         },
+                         onBack: this.onBack
+                     })
+                     return
+                }
+				
                 if(!a.query){
                     new Search({
                         input: params.search,

--- a/src/lang/be.js
+++ b/src/lang/be.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Ідзе пошук...',
     search_start: 'Пачаць пошук',
     search_nofound: 'Па вашым запыце нічога не знойдзена.',
+	global_search: 'Сусветны пошук',
 
     full_genre: 'Жанр',
     full_production: 'Вытворчасць',

--- a/src/lang/bg.js
+++ b/src/lang/bg.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Търсенето е в ход...',
     search_start: 'За да започнете търсене',
     search_nofound: 'Нищо не беше намерено според вашата заявка.',
+	global_search: 'Глобално търсене',
 
     full_genre: 'Жанр',
     full_production: 'Продукция',

--- a/src/lang/cs.js
+++ b/src/lang/cs.js
@@ -26,6 +26,7 @@ export default {
     search_searching: "Probíhá hledání...",
     search_start: "Začít hledat",
     search_nofound: "Podle vašeho dotazu nebylo nic nalezeno.",
+	global_search: 'Globální vyhledávání',
 
     full_genre: "Žánr",
     full_production: "Produkce",

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Search in progress...',
     search_start: 'To start searching',
     search_nofound: 'Nothing was found according to your request.',
+	global_search: 'Global search',
 
     full_genre: 'Genre',
     full_production: 'Production',

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Recherche en cours...',
     search_start: 'Pour commencer la recherche',
     search_nofound: 'Aucun résultat ne correspond à votre requête.',
+	global_search: 'Recherche globale',
 
     full_genre: 'Genre',
     full_production: 'Production',

--- a/src/lang/he.js
+++ b/src/lang/he.js
@@ -23,6 +23,7 @@ export default {
     search_searching: 'חיפוש בתהליך...',
     search_start: 'להתחיל לחפש',
     search_nofound: 'שום דבר לא נמצא לפי בקשתך',
+	global_search: 'חיפוש כללי',
     full_genre: 'סגנון',
     full_production: 'הפקה',
     full_date_of_release: 'תאריך השקה',

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Procura em progresso...',
     search_start: 'Começar a pesquisar',
     search_nofound: 'Não encontrámos nada relacionado com a sua pesquisa.',
+	global_search: 'Pesquisa global',
 
     full_genre: 'Gênero',
     full_production: 'Produção',

--- a/src/lang/ro.js
+++ b/src/lang/ro.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Căutare în curs...',
     search_start: 'Pentru a începe căutarea',
     search_nofound: 'Nu s-a găsit nimic conform solicitării tale.',
+	global_search: 'Căutare globală',
 
     full_genre: 'Gen',
     full_production: 'Producție',

--- a/src/lang/ru.js
+++ b/src/lang/ru.js
@@ -26,6 +26,7 @@ export default {
     search_searching: 'Идет поиск...',
     search_start: 'Начать поиск',
     search_nofound: 'По вашему запросу ничего не найдено.',
+	global_search: 'Глобальный поиск',
 
     full_genre: 'Жанр',
     full_production: 'Производство',

--- a/src/lang/uk.js
+++ b/src/lang/uk.js
@@ -24,6 +24,7 @@ export default {
     search_searching: 'Йде пошук...',
     search_start: 'Розпочати пошук',
     search_nofound: 'На ваш запит нічого не знайдено.',
+	global_search: 'Глобальний пошук',
     full_genre: 'Жанр',
     full_production: 'Виробництво',
     full_date_of_release: 'Дата релізу',

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -24,6 +24,7 @@ export default {
     search_searching: '搜索中...',
     search_start: '开始搜索',
     search_nofound: '根据您的要求没有找到相关内容。',
+	global_search: '全局搜索',
     full_genre: '类型',
     full_production: '出品公司',
     full_date_of_release: '发布日期',


### PR DESCRIPTION
Global search for jackett/prowlarr, all other options work as before, global search without categories has simply been added as an alternative option. I've also fixed the categories for Prowlarr that weren't working.

<img width="299" height="343" alt="Screenshot 2026-05-11 205319" src="https://github.com/user-attachments/assets/265afed1-7399-4676-81b4-a585641597d1" />

https://github.com/user-attachments/assets/4e5c79f0-f7ab-498e-9d85-0b89a5325bdc

