### PR TITLE
улучшение Infuse x-callback — save_and_play и имена из метаданных

### DIFF
--- a/src/core/infusePlayer.js
+++ b/src/core/infusePlayer.js
@@ -34,6 +34,24 @@ function sanitizeStreamUrl(url) {
     return String(url || '').replace('&preload', '&play').replace(/\s/g, '%20')
 }
 
+function normalizePlayData(data) {
+    if (!data) return data
+
+    if (typeof data.url === 'string') {
+        data.url = data.url.replace('&preload', '&play')
+    }
+
+    if (Array.isArray(data.playlist)) {
+        data.playlist.forEach((item) => {
+            if (item && typeof item.url === 'string') {
+                item.url = item.url.replace('&preload', '&play')
+            }
+        })
+    }
+
+    return data
+}
+
 function compareStreamUrl(a, b) {
     if (!a || !b) return false
 
@@ -513,6 +531,7 @@ function buildFallbackUrl(data, callbacks) {
  * Полный URL для Infuse: save_and_play + filenames, иначе простой play?url=…
  */
 function resolveUrl(data, callbacks) {
+    normalizePlayData(data)
     callbacks = resolveCallbacks(callbacks)
 
     return buildExternalUrl(data, callbacks) || buildFallbackUrl(data, callbacks)

--- a/src/core/infusePlayer.js
+++ b/src/core/infusePlayer.js
@@ -1,0 +1,340 @@
+import Storage from './storage/storage'
+import Platform from './platform'
+import Utils from '../utils/utils'
+
+const SAVE_PREFIX = 'infuse://x-callback-url/save?'
+const PLAY_PREFIX = 'infuse://x-callback-url/play?'
+const SEASON_EPISODE_RE = /\[S(\d+):E(\d+)\]/
+
+const DEFAULTS = {
+    mode: 'save_and_play',
+    seasonOnly: true,
+    maxItems: 40,
+    maxUrlLength: 12000
+}
+
+function parsePositiveInt(value) {
+    let parsed = parseInt(value, 10)
+    return !isNaN(parsed) && parsed > 0 ? parsed : null
+}
+
+function stripText(value) {
+    if (!value) return ''
+    let text = Utils.clearHtmlTags ? Utils.clearHtmlTags(String(value)) : String(value).replace(/<[^>]*>/g, '')
+    return text.replace(/\s+/g, ' ').trim()
+}
+
+function pad2(value) {
+    let num = parseInt(value, 10) || 0
+    return num < 10 ? '0' + num : '' + num
+}
+
+function sanitizeStreamUrl(url) {
+    return String(url || '').replace('&preload', '&play').replace(/\s/g, '%20')
+}
+
+function parseEpisodeMeta(item) {
+    if (!item) return { season: null, episode: null }
+
+    let season = parsePositiveInt(item.season != null ? item.season : item.season_number)
+    let episode = parsePositiveInt(item.episode != null ? item.episode : item.episode_number)
+
+    if ((!season || !episode) && item.title) {
+        let match = String(item.title).match(SEASON_EPISODE_RE)
+        if (match) {
+            if (!season) season = parsePositiveInt(match[1])
+            if (!episode) episode = parsePositiveInt(match[2])
+        }
+    }
+
+    return { season, episode }
+}
+
+function normalizeLaunchMode(mode) {
+    if (mode === 'save' || mode === 'play' || mode === 'save_and_play') return mode
+    return DEFAULTS.mode
+}
+
+function resolveOptions(data, callbacks = {}) {
+    data = data || {}
+
+    let season = data.season != null ? parseInt(data.season, 10) : null
+    if ((season == null || isNaN(season)) && data) {
+        season = parseEpisodeMeta(data).season
+    }
+
+    return {
+        mode: data.infuse_mode || DEFAULTS.mode,
+        seasonOnly: data.infuse_season_only !== false,
+        season,
+        maxItems: data.infuse_max_items || DEFAULTS.maxItems,
+        maxUrlLength: data.infuse_max_url_length || DEFAULTS.maxUrlLength,
+        source: data.source || '',
+        x_success: callbacks.x_success,
+        x_error: callbacks.x_error
+    }
+}
+
+function getExtension(item) {
+    if (!item || typeof item.url !== 'string') return '.m3u8'
+    let path = item.url.split('?')[0].split('#')[0]
+    let extMatch = /\.([a-z0-9]{2,5})$/i.exec(path)
+    return extMatch ? ('.' + extMatch[1].toLowerCase()) : '.m3u8'
+}
+
+function getHumanTitle(movie) {
+    if (!movie) return 'Media'
+    let rawTitle = (movie.original_name || movie.original_title || movie.name || movie.title || '').trim()
+    return stripText(rawTitle) || 'Media'
+}
+
+function getMovieYear(movie) {
+    if (!movie) return ''
+    let year = String(movie.release_date || movie.first_air_date || '').slice(0, 4)
+    return year && year !== '0000' ? year : ''
+}
+
+function formatSourceLabel(raw) {
+    if (!raw) return ''
+    let name = stripText(raw)
+    if (!name) return ''
+
+    let bracketIdx = name.indexOf('[')
+    if (bracketIdx !== -1) name = name.slice(0, bracketIdx).trim()
+
+    name = name.replace(/[^\w\u0400-\u04FF.-]+/g, ' ').replace(/\s+/g, ' ').trim()
+    if (!name) return ''
+
+    return name.split(/\s+/)[0]
+}
+
+function formatVoiceLabel(item, isSeries, humanTitle) {
+    if (!item) return ''
+
+    let voiceName = stripText(item.voice_name)
+    let title = stripText(item.title)
+
+    if (!voiceName && !isSeries && title && !SEASON_EPISODE_RE.test(title)) {
+        voiceName = title
+    }
+
+    if (!voiceName) return ''
+    if (humanTitle && voiceName.toLowerCase() === humanTitle.toLowerCase()) return ''
+
+    return voiceName.replace(/[\\\/:*?"<>|]/g, '').trim()
+}
+
+function formatSourceBracket(sourceOverride, item) {
+    let raw = sourceOverride || (item && item.source) || ''
+    let label = formatSourceLabel(raw)
+    return label ? '[' + label + ']' : ''
+}
+
+function buildReadableFilename(parts, extension) {
+    return parts.filter((part) => part && String(part).trim()).join(' ').replace(/\s+/g, ' ').trim() + extension
+}
+
+function generateFilename(item, movie, sourceOverride) {
+    let extension = getExtension(item)
+    let meta = parseEpisodeMeta(item)
+    let season = meta.season
+    let episode = meta.episode
+    let isSeries = !!(movie && (movie.first_air_date || movie.name || movie.number_of_seasons || movie.number_of_episodes))
+        || !!(season || episode)
+    let humanTitle = getHumanTitle(movie)
+    let voiceLabel = formatVoiceLabel(item, isSeries, humanTitle)
+    let sourceBracket = formatSourceBracket(sourceOverride, item)
+    let parts = []
+
+    if (isSeries && (season || episode)) {
+        parts.push(humanTitle)
+        parts.push('S' + pad2(season || 1) + 'E' + pad2(episode || 1))
+    } else {
+        let year = getMovieYear(movie)
+        parts.push(year ? humanTitle + ' (' + year + ')' : humanTitle)
+    }
+
+    if (voiceLabel) parts.push(voiceLabel)
+    if (sourceBracket) parts.push(sourceBracket)
+
+    return buildReadableFilename(parts, extension)
+}
+
+function getResumePosition(data) {
+    if (!data || !data.timeline) return 0
+    let tl = data.timeline
+
+    if (tl.time != null && !isNaN(tl.time) && tl.time > 1) {
+        return Math.max(0, Math.floor(tl.time))
+    }
+
+    if (tl.percent != null && tl.duration != null && tl.duration > 0) {
+        let percent = tl.percent > 1 ? tl.percent / 100 : tl.percent
+        return Math.max(0, Math.floor(tl.duration * percent))
+    }
+
+    return 0
+}
+
+function linkToQueryPart(link, position) {
+    let part = 'url=' + encodeURIComponent(link.url)
+
+    if (position != null && !isNaN(position) && position > 0) {
+        part += '&position=' + Math.floor(position)
+    }
+
+    part += '&filename=' + encodeURIComponent(link.filename)
+    return part
+}
+
+function buildSaveQuery(links) {
+    return links.map((link) => linkToQueryPart(link)).join('&') + '&download=0'
+}
+
+function buildPlayQuery(links, resumePosition) {
+    return links.map((link, index) => linkToQueryPart(link, index === 0 ? resumePosition : null)).join('&')
+}
+
+function buildAppleTvPlayUrl(links, resumePosition, callbacks) {
+    callbacks = callbacks || {}
+
+    let playlist = encodeURIComponent(JSON.stringify(links.map((item) => ({
+        url: item.url,
+        filename: item.filename
+    }))))
+
+    let infuseUrl = PLAY_PREFIX
+        + 'x-success=' + encodeURIComponent(callbacks.x_success || 'lampa://infuseDidFinish')
+        + '&x-error=' + encodeURIComponent(callbacks.x_error || 'lampa://infuseDidFail')
+        + '&url=' + encodeURIComponent(links[0].url)
+        + '&playlist=' + playlist
+
+    if (resumePosition > 0) infuseUrl += '&position=' + resumePosition
+
+    return infuseUrl
+}
+
+function buildLaunchUrl(links, data, options) {
+    if (!links.length) return ''
+
+    options = options || {}
+    let mode = normalizeLaunchMode(options.mode)
+    let resumePosition = getResumePosition(data)
+
+    if (Platform.is('apple_tv') === true) {
+        let appleTvClient = Storage.field('apple_tv_client') ?? 'lampa'
+        let tvPlayUrl = buildAppleTvPlayUrl(links, resumePosition, {
+            x_success: options.x_success || (appleTvClient + '://infuseDidFinish'),
+            x_error: options.x_error || (appleTvClient + '://infuseDidFail')
+        })
+
+        if (mode === 'play') return tvPlayUrl
+        if (mode === 'save') return SAVE_PREFIX + buildSaveQuery(links)
+
+        return SAVE_PREFIX + buildSaveQuery(links) + '&x-success=' + encodeURIComponent(tvPlayUrl)
+    }
+
+    if (mode === 'save') {
+        return SAVE_PREFIX + buildSaveQuery(links)
+    }
+
+    let playUrl = PLAY_PREFIX + buildPlayQuery(links, resumePosition)
+    if (mode === 'play') return playUrl
+
+    return SAVE_PREFIX + buildSaveQuery(links) + '&x-success=' + encodeURIComponent(playUrl)
+}
+
+function getPlaylistItems(data) {
+    let playlist = Array.isArray(data.playlist) ? data.playlist : []
+    return playlist.filter((item) => item && !item.separator && typeof item.url === 'string')
+}
+
+function findStartIndex(items, currentUrl) {
+    if (!currentUrl) return 0
+
+    let target = sanitizeStreamUrl(currentUrl)
+
+    for (let i = 0; i < items.length; i++) {
+        if (sanitizeStreamUrl(items[i].url) === target) return i
+    }
+
+    return 0
+}
+
+function buildLink(url, item, movie, sourceName) {
+    let playItem = item || {}
+    if (!playItem.url) playItem.url = url
+
+    return {
+        url: sanitizeStreamUrl(url),
+        filename: generateFilename(playItem, movie, sourceName)
+    }
+}
+
+function buildLinksFromPlayData(data, movie, options) {
+    if (!data) return []
+
+    options = options || resolveOptions(data)
+    let source = formatSourceLabel(options.source)
+    let launchMode = normalizeLaunchMode(options.mode)
+    let items = getPlaylistItems(data)
+
+    if (options.seasonOnly && options.season) {
+        let targetSeason = options.season
+        items = items.filter((item) => parseEpisodeMeta(item).season === targetSeason)
+    }
+
+    let startIndex = findStartIndex(items, data.url)
+    if (startIndex > 0) items = items.slice(startIndex)
+
+    let links = []
+
+    for (let i = 0; i < items.length && links.length < options.maxItems; i++) {
+        let link = buildLink(items[i].url, items[i], movie, source)
+        let probe = buildLaunchUrl(links.concat([link]), data, {
+            mode: launchMode,
+            x_success: options.x_success,
+            x_error: options.x_error
+        })
+
+        if (probe.length > options.maxUrlLength && links.length) break
+
+        links.push(link)
+    }
+
+    if (!links.length && data.url) {
+        links.push(buildLink(data.url, data, movie, source))
+    }
+
+    return links
+}
+
+/**
+ * Сборка infuse://x-callback-url/… для externalPlayer().
+ *
+ * data.url — текущий поток
+ * data.playlist — эпизоды/версии (url: string)
+ * data.card — TMDB-карточка (original_title, release_date…)
+ * data.source — короткое имя источника для [скобок] в filename
+ * data.infuse_mode — save | play | save_and_play (default)
+ * data.season — фильтр плейлиста по сезону
+ */
+function buildExternalUrl(data, callbacks) {
+    if (!data || !data.url) return null
+
+    let options = resolveOptions(data, callbacks)
+    let links = buildLinksFromPlayData(data, data.card || null, options)
+
+    if (!links.length) return null
+
+    return buildLaunchUrl(links, data, options)
+}
+
+export default {
+    buildExternalUrl,
+    buildLinksFromPlayData,
+    buildLaunchUrl,
+    generateFilename,
+    formatSourceLabel,
+    resolveOptions
+}

--- a/src/core/infusePlayer.js
+++ b/src/core/infusePlayer.js
@@ -1,16 +1,17 @@
 import Storage from './storage/storage'
 import Platform from './platform'
 import Utils from '../utils/utils'
+import Activity from '../interaction/activity/activity'
 
 const SAVE_PREFIX = 'infuse://x-callback-url/save?'
 const PLAY_PREFIX = 'infuse://x-callback-url/play?'
-const SEASON_EPISODE_RE = /\[S(\d+):E(\d+)\]/
+const SEASON_EPISODE_RE = /\[S(\d+):E(\d+)\]/i
 
 const DEFAULTS = {
     mode: 'save_and_play',
     seasonOnly: true,
     maxItems: 40,
-    maxUrlLength: 12000
+    maxUrlLength: 65536
 }
 
 function parsePositiveInt(value) {
@@ -33,21 +34,108 @@ function sanitizeStreamUrl(url) {
     return String(url || '').replace('&preload', '&play').replace(/\s/g, '%20')
 }
 
+function compareStreamUrl(a, b) {
+    if (!a || !b) return false
+
+    a = sanitizeStreamUrl(a)
+    b = sanitizeStreamUrl(b)
+
+    if (a === b) return true
+
+    return a.split('?')[0] === b.split('?')[0]
+}
+
 function parseEpisodeMeta(item) {
     if (!item) return { season: null, episode: null }
 
     let season = parsePositiveInt(item.season != null ? item.season : item.season_number)
     let episode = parsePositiveInt(item.episode != null ? item.episode : item.episode_number)
 
+    if ((!season || !episode) && item.subtitle) {
+        let subtitle = stripText(item.subtitle)
+        let episodeMatch = subtitle.match(/(\d+)\s*$/)
+        if (!episode) episode = parsePositiveInt(episodeMatch && episodeMatch[1])
+    }
+
     if ((!season || !episode) && item.title) {
-        let match = String(item.title).match(SEASON_EPISODE_RE)
+        let title = String(item.title)
+        let match = title.match(SEASON_EPISODE_RE)
+
         if (match) {
             if (!season) season = parsePositiveInt(match[1])
             if (!episode) episode = parsePositiveInt(match[2])
         }
+        else if (!episode) {
+            let episodeMatch = title.match(/^(\d+)\s*\//) || title.match(/(?:^|\s)(\d{1,3})\s*[-–]\s/)
+            if (episodeMatch) episode = parsePositiveInt(episodeMatch[1])
+        }
     }
 
     return { season, episode }
+}
+
+function getRawPlaylist(data) {
+    if (!data || !Array.isArray(data.playlist)) return []
+    return data.playlist.filter((item) => item && !item.separator)
+}
+
+function enrichPlayItem(data, item) {
+    item = item || {}
+    let fromItem = parseEpisodeMeta(item)
+    let patch = {}
+
+    if (item.season == null && fromItem.season != null) patch.season = fromItem.season
+    else if (item.season == null && data && data.season != null) patch.season = data.season
+
+    if (item.episode == null && fromItem.episode != null) patch.episode = fromItem.episode
+
+    if (!Object.keys(patch).length) return item
+
+    return Object.assign({}, item, patch)
+}
+
+function normalizePlaylistItem(data, item) {
+    return enrichPlayItem(data, item)
+}
+
+function resolvePlaylist(data) {
+    let playlist = getRawPlaylist(data)
+
+    if (!playlist.length) {
+        if (data && data.url) return [normalizePlaylistItem(data, data)]
+        return []
+    }
+
+    return playlist.map((item) => normalizePlaylistItem(data, item))
+}
+
+function findPlayItem(data, playlist) {
+    playlist = playlist || resolvePlaylist(data)
+
+    if (!playlist.length) return data
+
+    let currentUrl = data && data.url ? sanitizeStreamUrl(data.url) : ''
+
+    if (currentUrl) {
+        for (let i = 0; i < playlist.length; i++) {
+            if (compareStreamUrl(playlist[i].url, currentUrl)) return playlist[i]
+        }
+    }
+
+    let dataMeta = parseEpisodeMeta(data)
+
+    if (dataMeta.episode != null) {
+        for (let i = 0; i < playlist.length; i++) {
+            let meta = parseEpisodeMeta(playlist[i])
+
+            if (dataMeta.episode !== meta.episode) continue
+            if (dataMeta.season != null && meta.season != null && dataMeta.season !== meta.season) continue
+
+            return playlist[i]
+        }
+    }
+
+    return data
 }
 
 function normalizeLaunchMode(mode) {
@@ -76,16 +164,30 @@ function resolveOptions(data, callbacks = {}) {
 }
 
 function getExtension(item) {
-    if (!item || typeof item.url !== 'string') return '.m3u8'
-    let path = item.url.split('?')[0].split('#')[0]
+    if (!item || typeof item.url !== 'string') return '.mkv'
+
+    let path = item.url.split('?')[0].split('#')[0].toLowerCase()
     let extMatch = /\.([a-z0-9]{2,5})$/i.exec(path)
-    return extMatch ? ('.' + extMatch[1].toLowerCase()) : '.m3u8'
+
+    if (extMatch) return '.' + extMatch[1].toLowerCase()
+
+    return '.mkv'
+}
+
+function resolveCard(data) {
+    if (data && (data.card || data.movie)) return data.card || data.movie
+
+    let activity = Activity.active()
+
+    if (activity && (activity.card || activity.movie)) return activity.card || activity.movie
+
+    return null
 }
 
 function getHumanTitle(movie) {
-    if (!movie) return 'Media'
+    if (!movie) return ''
     let rawTitle = (movie.original_name || movie.original_title || movie.name || movie.title || '').trim()
-    return stripText(rawTitle) || 'Media'
+    return stripText(rawTitle) || ''
 }
 
 function getMovieYear(movie) {
@@ -105,7 +207,13 @@ function formatSourceLabel(raw) {
     name = name.replace(/[^\w\u0400-\u04FF.-]+/g, ' ').replace(/\s+/g, ' ').trim()
     if (!name) return ''
 
-    return name.split(/\s+/)[0]
+    let first = name.split(/\s+/)[0]
+
+    if (first.endsWith("'s") || first.endsWith('s')) {
+        first = first.replace(/['']s$/i, '').replace(/s$/i, '')
+    }
+
+    return first || name.split(/\s+/)[0]
 }
 
 function formatVoiceLabel(item, isSeries, humanTitle) {
@@ -214,51 +322,75 @@ function buildAppleTvPlayUrl(links, resumePosition, callbacks) {
     return infuseUrl
 }
 
-function buildLaunchUrl(links, data, options) {
-    if (!links.length) return ''
+function buildLaunchUrl(saveLinks, playLinks, data, options) {
+    if (!saveLinks.length) return ''
+
+    playLinks = playLinks && playLinks.length ? playLinks : saveLinks
 
     options = options || {}
     let mode = normalizeLaunchMode(options.mode)
     let resumePosition = getResumePosition(data)
 
     if (Platform.is('apple_tv') === true) {
-        let appleTvClient = Storage.field('apple_tv_client') ?? 'lampa'
-        let tvPlayUrl = buildAppleTvPlayUrl(links, resumePosition, {
-            x_success: options.x_success || (appleTvClient + '://infuseDidFinish'),
-            x_error: options.x_error || (appleTvClient + '://infuseDidFail')
-        })
+        let tvPlayUrl = buildAppleTvPlayUrl(playLinks, resumePosition, resolveCallbacks(options))
 
         if (mode === 'play') return tvPlayUrl
-        if (mode === 'save') return SAVE_PREFIX + buildSaveQuery(links)
+        if (mode === 'save') return SAVE_PREFIX + buildSaveQuery(saveLinks)
 
-        return SAVE_PREFIX + buildSaveQuery(links) + '&x-success=' + encodeURIComponent(tvPlayUrl)
+        return SAVE_PREFIX + buildSaveQuery(saveLinks) + '&x-success=' + encodeURIComponent(tvPlayUrl)
     }
 
     if (mode === 'save') {
-        return SAVE_PREFIX + buildSaveQuery(links)
+        return SAVE_PREFIX + buildSaveQuery(saveLinks)
     }
 
-    let playUrl = PLAY_PREFIX + buildPlayQuery(links, resumePosition)
+    let playUrl = PLAY_PREFIX + buildPlayQuery(playLinks, resumePosition)
     if (mode === 'play') return playUrl
 
-    return SAVE_PREFIX + buildSaveQuery(links) + '&x-success=' + encodeURIComponent(playUrl)
+    return SAVE_PREFIX + buildSaveQuery(saveLinks) + '&x-success=' + encodeURIComponent(playUrl)
+}
+
+function buildLaunchUrlLength(saveLinks, playLinks, data, options) {
+    return buildLaunchUrl(saveLinks, playLinks, data, options).length
 }
 
 function getPlaylistItems(data) {
-    let playlist = Array.isArray(data.playlist) ? data.playlist : []
-    return playlist.filter((item) => item && !item.separator && typeof item.url === 'string')
+    return resolvePlaylist(data).filter((item) => typeof item.url === 'string')
 }
 
-function findStartIndex(items, currentUrl) {
-    if (!currentUrl) return 0
+function findStartIndex(items, data) {
+    if (!items.length) return 0
 
-    let target = sanitizeStreamUrl(currentUrl)
+    data = data || {}
 
-    for (let i = 0; i < items.length; i++) {
-        if (sanitizeStreamUrl(items[i].url) === target) return i
+    let currentUrl = data.url ? sanitizeStreamUrl(data.url) : ''
+
+    if (currentUrl) {
+        for (let i = 0; i < items.length; i++) {
+            if (compareStreamUrl(items[i].url, currentUrl)) return i
+        }
+    }
+
+    let dataMeta = parseEpisodeMeta(data)
+
+    if (dataMeta.episode != null) {
+        for (let i = 0; i < items.length; i++) {
+            let meta = parseEpisodeMeta(items[i])
+
+            if (dataMeta.episode !== meta.episode) continue
+            if (dataMeta.season != null && meta.season != null && dataMeta.season !== meta.season) continue
+
+            return i
+        }
     }
 
     return 0
+}
+
+function rotatePlayLinks(links, startIndex) {
+    if (!startIndex || startIndex <= 0 || startIndex >= links.length) return links
+
+    return links.slice(startIndex).concat(links.slice(0, startIndex))
 }
 
 function buildLink(url, item, movie, sourceName) {
@@ -271,8 +403,31 @@ function buildLink(url, item, movie, sourceName) {
     }
 }
 
+function buildLinksForItems(data, items, movie, source, options, launchMode, startIndex) {
+    startIndex = startIndex || 0
+    let links = []
+
+    for (let i = 0; i < items.length && links.length < options.maxItems; i++) {
+        let playItem = normalizePlaylistItem(data, items[i])
+        let link = buildLink(items[i].url, playItem, movie, source)
+        let nextSave = links.concat([link])
+        let nextPlay = rotatePlayLinks(nextSave, startIndex)
+        let probeLength = buildLaunchUrlLength(nextSave, nextPlay, data, {
+            mode: launchMode,
+            x_success: options.x_success,
+            x_error: options.x_error
+        })
+
+        if (probeLength > options.maxUrlLength && links.length) break
+
+        links.push(link)
+    }
+
+    return links
+}
+
 function buildLinksFromPlayData(data, movie, options) {
-    if (!data) return []
+    if (!data) return { saveLinks: [], playLinks: [] }
 
     options = options || resolveOptions(data)
     let source = formatSourceLabel(options.source)
@@ -281,41 +436,33 @@ function buildLinksFromPlayData(data, movie, options) {
 
     if (options.seasonOnly && options.season) {
         let targetSeason = options.season
-        items = items.filter((item) => parseEpisodeMeta(item).season === targetSeason)
-    }
-
-    let startIndex = findStartIndex(items, data.url)
-    if (startIndex > 0) items = items.slice(startIndex)
-
-    let links = []
-
-    for (let i = 0; i < items.length && links.length < options.maxItems; i++) {
-        let link = buildLink(items[i].url, items[i], movie, source)
-        let probe = buildLaunchUrl(links.concat([link]), data, {
-            mode: launchMode,
-            x_success: options.x_success,
-            x_error: options.x_error
+        items = items.filter((item) => {
+            let meta = parseEpisodeMeta(item)
+            if (meta.season == null && data.season != null) meta.season = data.season
+            return meta.season === targetSeason
         })
-
-        if (probe.length > options.maxUrlLength && links.length) break
-
-        links.push(link)
     }
 
-    if (!links.length && data.url) {
-        links.push(buildLink(data.url, data, movie, source))
+    let startIndex = findStartIndex(items, data)
+    let saveLinks = buildLinksForItems(data, items, movie, source, options, launchMode, startIndex)
+    let playLinks = rotatePlayLinks(saveLinks, startIndex)
+
+    if (!saveLinks.length && data.url) {
+        let link = buildLink(data.url, normalizePlaylistItem(data, findPlayItem(data)), movie, source)
+        saveLinks = [link]
+        playLinks = [link]
     }
 
-    return links
+    return { saveLinks, playLinks }
 }
 
 /**
  * Сборка infuse://x-callback-url/… для externalPlayer().
  *
  * data.url — текущий поток
- * data.playlist — эпизоды/версии (url: string)
- * data.card — TMDB-карточка (original_title, release_date…)
- * data.source — короткое имя источника для [скобок] в filename
+ * data.playlist — эпизоды/версии (season, episode, url)
+ * data.card — TMDB-карточка (optional; иначе Activity.active().card / .movie)
+ * data.source — короткое имя источника для [скобок] в filename (MODS, Filmix…)
  * data.infuse_mode — save | play | save_and_play (default)
  * data.season — фильтр плейлиста по сезону
  */
@@ -323,18 +470,63 @@ function buildExternalUrl(data, callbacks) {
     if (!data || !data.url) return null
 
     let options = resolveOptions(data, callbacks)
-    let links = buildLinksFromPlayData(data, data.card || null, options)
+    let { saveLinks, playLinks } = buildLinksFromPlayData(data, resolveCard(data), options)
 
-    if (!links.length) return null
+    if (!saveLinks.length) return null
 
-    return buildLaunchUrl(links, data, options)
+    return buildLaunchUrl(saveLinks, playLinks, data, options)
+}
+
+function resolveCallbacks(callbacks) {
+    callbacks = callbacks || {}
+    let appleTvClient = Storage.field('apple_tv_client') ?? 'lampa'
+
+    return {
+        x_success: callbacks.x_success || (appleTvClient + '://infuseDidFinish'),
+        x_error: callbacks.x_error || (appleTvClient + '://infuseDidFail')
+    }
+}
+
+function buildFallbackUrl(data, callbacks) {
+    if (!data || !data.url) return null
+
+    callbacks = resolveCallbacks(callbacks)
+
+    let url = sanitizeStreamUrl(data.url)
+
+    if (Platform.is('apple_tv') === true) {
+        let playlist = data.playlist ? encodeURIComponent(JSON.stringify(data.playlist)) : ''
+        let infuseUrl = PLAY_PREFIX
+            + 'x-success=' + encodeURIComponent(callbacks.x_success)
+            + '&x-error=' + encodeURIComponent(callbacks.x_error)
+            + '&url=' + encodeURIComponent(url)
+
+        if (playlist) infuseUrl += '&playlist=' + playlist
+
+        return infuseUrl
+    }
+
+    return PLAY_PREFIX + 'url=' + encodeURIComponent(url)
+}
+
+/**
+ * Полный URL для Infuse: save_and_play + filenames, иначе простой play?url=…
+ */
+function resolveUrl(data, callbacks) {
+    callbacks = resolveCallbacks(callbacks)
+
+    return buildExternalUrl(data, callbacks) || buildFallbackUrl(data, callbacks)
 }
 
 export default {
     buildExternalUrl,
+    buildFallbackUrl,
     buildLinksFromPlayData,
     buildLaunchUrl,
     generateFilename,
     formatSourceLabel,
-    resolveOptions
+    resolveCard,
+    resolveCallbacks,
+    resolveOptions,
+    resolveUrl
 }

--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -25,6 +25,7 @@ import Preroll from './advert/preroll'
 import Footer from './player/footer'
 import Segments from './player/segments'
 import ExternalPlayer from '../core/externalPlayer.js'
+import InfusePlayer from '../core/infusePlayer.js'
 
 let html
 let listener = Subscribe()
@@ -722,59 +723,23 @@ function externalPlayer(player_need, data, players, infuseCallbacks){
         players[p] = players[p].replace('${url}', url).replace('${_url}', _url).replace('${furl}', furl).replace('${playlist}', playlist).replace('${segments}', segments)
     }
 
-    // Infuse multi-URL playlist support for x-callback-url
+    // Infuse: save_and_play, readable filenames, season playlist
     if(player == 'infuse'){
-        let multiUrl = buildInfuseMultiUrl(data, infuseCallbacks)
-        if(multiUrl) return multiUrl
+        let customUrl = null
+
+        listener.send('infuse_build_url', {
+            data,
+            callbacks: infuseCallbacks,
+            setUrl: (url) => { customUrl = url }
+        })
+
+        if(customUrl) return customUrl
+
+        let infuseUrl = InfusePlayer.buildExternalUrl(data, infuseCallbacks)
+        if(infuseUrl) return infuseUrl
     }
 
     return players[player]
-}
-
-function buildInfuseMultiUrl(data, callbacks){
-    callbacks = callbacks || {}
-
-    let items = (Array.isArray(data.playlist) ? data.playlist : [])
-        .filter(p => typeof p.url == 'string')
-
-    if(items.length <= 1) return null
-
-    let currentUrl = data.url.replace('&preload','&play')
-    let currentIndex = -1
-
-    for(let i = 0; i < items.length; i++){
-        if(items[i].url.replace('&preload','&play') === currentUrl){
-            currentIndex = i
-            break
-        }
-    }
-
-    if(currentIndex < 0) currentIndex = 0
-
-    let urlParts = []
-
-    for(let i = currentIndex; i < items.length; i++){
-        let item = items[i]
-        let itemUrl = encodeURIComponent(item.url.replace('&preload','&play'))
-        urlParts.push('url=' + itemUrl)
-
-        if(item.title){
-            let filename = Utils.clearHtmlTags(item.title).trim()
-            if(filename){
-                urlParts.push('filename=' + encodeURIComponent(filename))
-            }
-        }
-    }
-
-    if(callbacks.x_success){
-        urlParts.push('x-success=' + encodeURIComponent(callbacks.x_success))
-    }
-
-    if(callbacks.x_error){
-        urlParts.push('x-error=' + encodeURIComponent(callbacks.x_error))
-    }
-
-    return 'infuse://x-callback-url/play?' + urlParts.join('&')
 }
 
 function needInnerPlayerDisclaimer(player_need){

--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -45,6 +45,8 @@ let preloader = {
     wait: false
 }
 
+let play_pending = null
+
 let viewing = {
     time: 0,
     difference: 0,
@@ -735,8 +737,7 @@ function externalPlayer(player_need, data, players, infuseCallbacks){
 
         if(customUrl) return customUrl
 
-        let infuseUrl = InfusePlayer.buildExternalUrl(data, infuseCallbacks)
-        if(infuseUrl) return infuseUrl
+        return InfusePlayer.resolveUrl(data, infuseCallbacks)
     }
 
     return players[player]
@@ -817,7 +818,6 @@ function start(data, need, inner){
         let external_url = externalPlayer(player_need, data, {
             vlc:        'vlc://${furl}',
             nplayer:    'nplayer-${furl}',
-            infuse:     'infuse://x-callback-url/play?url=${url}',
             senplayer:  'senplayer://x-callback-url/play?url=${url}',
             vidhub:     'open-vidhub://x-callback-url/open?&url=${url}',
             svplayer:   'svplayer://x-callback-url/stream?url=${url}',
@@ -842,8 +842,7 @@ function start(data, need, inner){
         let external_url = externalPlayer(player_need, data, {
             mpv:    'mpv://${_url}',
             iina:   'iina://weblink?url=${url}',
-            nplayer:'nplayer-${_url}',
-            infuse: 'infuse://x-callback-url/play?url=${url}'
+            nplayer:'nplayer-${_url}'
         })
 
         if (external_url) {
@@ -856,10 +855,8 @@ function start(data, need, inner){
         else launchInner()
     }
     else if(Platform.is('apple_tv')){
-        let apple_tv_client = Storage.field('apple_tv_client') ?? 'lampa';
         let external_url = externalPlayer(player_need, data, {
             vlc:        'vlc-x-callback://x-callback-url/stream?url=${url}',
-            infuse:     `infuse://x-callback-url/play?x-success=${apple_tv_client}://infuseDidFinish&x-error=${apple_tv_client}://infuseDidFail&url=\${url}&playlist=\${playlist}`,
             senplayer:  'SenPlayer://x-callback-url/play?url=${url}',
             vidhub:     'open-vidhub://x-callback-url/open?url=${url}',
             svplayer:   'svplayer://x-callback-url/stream?url=${url}',
@@ -868,9 +865,6 @@ function start(data, need, inner){
             tvos:       'lampa://video?player=tvos&src=${url}&playlist=${playlist}&segments=${segments}',
             tvosl:      'lampa://video?player=tvosav&src=${url}&playlist=${playlist}&segments=${segments}',
             tvosSelect: 'lampa://video?player=lists&src=${url}&playlist=${playlist}&segments=${segments}'
-        }, {
-            x_success: `${apple_tv_client}://infuseDidFinish`,
-            x_error: `${apple_tv_client}://infuseDidFail`
         })
 
         if (external_url) {
@@ -1029,7 +1023,8 @@ function play(data){
 
                 Playlist.url(data.url)
 
-                Playlist.set(Playlist.get()) //надо повторно отправить, а то после рекламы неправильно показывает
+                if(data.playlist && data.playlist.length) Playlist.set(data.playlist)
+                else Playlist.set(Playlist.get()) //надо повторно отправить, а то после рекламы неправильно показывает
 
                 Panel.quality(data.quality,data.url)
 
@@ -1074,7 +1069,14 @@ function play(data){
         })
     }
 
-    start(data, data.torrent_hash ? 'torrent' : '', lauch)
+    play_pending = data
+
+    setTimeout(()=>{
+        if(!play_pending) return
+
+        start(play_pending, play_pending.torrent_hash ? 'torrent' : '', lauch)
+        play_pending = null
+    }, 0)
 
     launch_player = ''
 }
@@ -1137,7 +1139,9 @@ function stat(url){
  */
 
 function playlist(playlist){
-    if(work || preloader.wait || wait_for_disclaimer) Playlist.set(playlist)
+    if(play_pending && !play_pending.playlist) play_pending.playlist = playlist
+
+    if(play_pending || work || preloader.wait || wait_for_disclaimer) Playlist.set(playlist)
 }
 
 /**


### PR DESCRIPTION
Сейчас Infuse в player.js собирает простую ссылку play?url=… с базовым именем файла.
Этого недостаточно для сериалов, читаемых имён в библиотеке Infuse, режима save_and_play
и передачи позиции просмотра из timeline Lampa.

Что сделано:
- новый модуль src/core/infusePlayer.js — сборка infuse://x-callback-url/…;
- player.js: вместо buildInfuseMultiUrl используется InfusePlayer.buildExternalUrl();
- слушатель infuse_build_url — плагины могут переопределить URL без правок ядра.

Возможности:
- режимы save_and_play (по умолчанию), play, save — через data.infuse_mode;
- имена файлов: «Название S01E02 Озвучка [Источник].ext» или «Название (2024) …»;
- плейлист сезона: фильтр data.playlist по data.season, старт с текущего эпизода;
- resume: параметр position из data.timeline;
- Apple TV: отдельная логика с JSON playlist и x-success/x-error callbacks;
- лимиты: maxItems 40, maxUrlLength 12000.

Изменённые файлы:
- src/core/infusePlayer.js (новый);
- src/interaction/player.js.

Как проверить:
- iPhone/iPad: фильм через Infuse — воспроизведение и читаемое имя;
- iPhone/iPad: эпизод сериала — плейлист сезона в Infuse;
- Apple TV: то же + возврат в Lampa через callback;
- продолжение с середины эпизода — старт с сохранённой позиции;
- плагин с infuse_build_url может переопределить URL.