### PR TITLE
feat(infuse): режим запуска, плейлисты и fix контекстного плеера

### DIFF
--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -501,6 +501,8 @@ function toggle(){
  */
 
 function backward(){
+    launch_player = ''
+
     destroy()
 
     if(callback) callback()
@@ -970,8 +972,6 @@ function start(data, need, inner){
         })
     }
     else launchInner()
-
-    launch_player = ''
 
     if(data.launch_player) delete data.launch_player
 }

--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -1113,12 +1113,8 @@ function play(data){
 
     if(launch_player) data.launch_player = launch_player
 
-    setTimeout(()=>{
-        if(!play_pending) return
-
-        start(play_pending, play_pending.torrent_hash ? 'torrent' : '', lauch)
-        play_pending = null
-    }, 0)
+    start(play_pending, play_pending.torrent_hash ? 'torrent' : '', lauch)
+    play_pending = null
 }
 
 function iptv(data){


### PR DESCRIPTION
## Summary
- Infuse: режим запуска (play / save / save_and_play / ask), метаданные в именах файлов, плейлист сезона, resolveUrl
- Torrent: нормализация preload-URL перед запуском Infuse
- Player: убран отложенный старт при playlist на play data
- Player: сохранение launch_player из контекстного меню («Lampa») при переключении серий до закрытия плеера

## Test plan
- [x] Infuse: настройки режима запуска, модалка ask
- [x] Torrent → Infuse: save / save_and_play
- [x] Контекстное меню «Lampa» при выбранном Infuse: переключение серий без модалки Infuse
- [x] Закрытие плеера: снова работает Infuse из настроек