### PR TITLE
Localize CUB-backed cards via TMDB metadata

### DIFF
--- a/src/components/feed.js
+++ b/src/components/feed.js
@@ -20,6 +20,65 @@ function Feed(object){
     let html    = document.createElement('div')
     let feed    = []
     let last
+
+    function enrichTmdbItem(element, oncomplite){
+        let card = element.data || {}
+
+        if(!card.imdb_id) return oncomplite(element)
+
+        let method = 'find/' + card.imdb_id + '?external_source=imdb_id'
+
+        Api.sources.tmdb.get(method, {}, (data)=>{
+            let movie = data.movie_results && data.movie_results[0]
+            let tv    = data.tv_results && data.tv_results[0]
+            let tmdb  = element.card_type == 'tv' ? tv || movie : movie || tv
+
+            if(tmdb){
+                tmdb.source = 'tmdb'
+                tmdb.imdb_id = card.imdb_id
+                tmdb.imdb_rating = card.imdb_rating
+                tmdb.kp_rating = card.kp_rating
+                tmdb.release_quality = card.release_quality
+                tmdb.countries = card.countries
+                tmdb.episode = card.episode
+
+                element.data = tmdb
+                element.card_id = tmdb.id
+                element.card_type = tmdb.name || tmdb.first_air_date ? 'tv' : 'movie'
+            }
+
+            oncomplite(element)
+        }, ()=>{
+            oncomplite(element)
+        }, {life: 60 * 24 * 7})
+    }
+
+    function enrichTmdbFeed(items, oncomplite){
+        let result = []
+        let index = 0
+        let active = 0
+        let limit = 4
+
+        function next(){
+            if(index >= items.length && active == 0) return oncomplite(result)
+
+            while(active < limit && index < items.length){
+                let position = index
+                let element = items[index]
+
+                index++
+                active++
+
+                enrichTmdbItem(element, (updated)=>{
+                    result[position] = updated
+                    active--
+                    next()
+                })
+            }
+        }
+
+        next()
+    }
     
     
     this.create = function(){
@@ -152,34 +211,36 @@ function Feed(object){
     }
 
     this.build = function(data){
-        feed = data.result
+        enrichTmdbFeed(data.result || [], (result)=>{
+            feed = result
 
-        html.addClass('feed')
+            html.addClass('feed')
 
-        let head = Template.js('feed_head')
+            let head = Template.js('feed_head')
 
-        head.find('.feed-head__title').text(Lang.translate('lampa_movie_title'))
-        head.find('.feed-head__info').html(Lang.translate('lampa_movie_descr'))
+            head.find('.feed-head__title').text(Lang.translate('lampa_movie_title'))
+            head.find('.feed-head__info').html(Lang.translate('lampa_movie_descr'))
 
-        head.on('hover:focus',scroll.update.bind(scroll, head))
+            head.on('hover:focus',scroll.update.bind(scroll, head))
 
-        scroll.minus()
+            scroll.minus()
 
-        scroll.onWheel = (step)=>{
-            Navigator.move(step > 0 ? 'down' : 'up')
-        }
+            scroll.onWheel = (step)=>{
+                Navigator.move(step > 0 ? 'down' : 'up')
+            }
 
-        scroll.onEnd = this.next.bind(this)
+            scroll.onEnd = this.next.bind(this)
 
-        scroll.append(head)
+            scroll.append(head)
 
-        this.append(feed.slice(0,20))
+            this.append(feed.slice(0,20))
 
-        html.append(scroll.render(true))
+            html.append(scroll.render(true))
 
-        this.activity.loader(false)
+            this.activity.loader(false)
 
-        this.activity.toggle()
+            this.activity.toggle()
+        })
     }
 
 

--- a/src/core/api/api.js
+++ b/src/core/api/api.js
@@ -210,9 +210,69 @@ function favorite(params = {}, oncomplite, onerror){
  * @param {function} oncomplite 
  * @param {function} onerror 
  */
+function reliseTmdbCard(card, oncomplite){
+    if(!card.imdb_id) return oncomplite(card)
+
+    let method = 'find/' + card.imdb_id + '?external_source=imdb_id'
+
+    TMDB.get(method, {}, (data)=>{
+        let movie = data.movie_results && data.movie_results[0]
+        let tv    = data.tv_results && data.tv_results[0]
+        let tmdb  = card.name || card.original_name || card.first_air_date ? tv || movie : movie || tv
+
+        if(tmdb){
+            tmdb.source = 'tmdb'
+            tmdb.imdb_id = card.imdb_id
+            tmdb.imdb_rating = card.imdb_rating
+            tmdb.kp_rating = card.kp_rating
+            tmdb.release_quality = card.release_quality
+        }
+
+        oncomplite(tmdb || card)
+    }, ()=>{
+        oncomplite(card)
+    }, {life: 60 * 24 * 7})
+}
+
+function reliseTmdbCards(items, oncomplite){
+    let result = []
+    let index = 0
+    let active = 0
+    let limit = 4
+
+    function next(){
+        if(index >= items.length && active == 0) return oncomplite(result)
+
+        while(active < limit && index < items.length){
+            let position = index
+            let card = items[index]
+
+            index++
+            active++
+
+            reliseTmdbCard(card, (tmdb)=>{
+                result[position] = tmdb
+                active--
+                next()
+            })
+        }
+    }
+
+    next()
+}
+
 function relise(params, oncomplite, onerror){
     network.silent(Utils.protocol() + 'tmdb.'+Manifest.cub_domain+'?sort=releases&results=20&page='+params.page,(data)=>{
-        oncomplite(Utils.addSource(data, 'cub'))
+        data = Utils.addSource(data, 'cub')
+
+        if(data.results && data.results.length){
+            reliseTmdbCards(data.results, (results)=>{
+                data.results = results
+
+                oncomplite(data)
+            })
+        }
+        else oncomplite(data)
     }, onerror)
 }
 


### PR DESCRIPTION
## Summary

This change keeps CUB as the source for the release and feed item lists, but resolves each item that has an IMDb id through TMDB's Find API:

```text
find/{imdb_id}?external_source=imdb_id
```

The resolved TMDB card is then used for display and navigation, while CUB ordering and item selection are preserved.

## Why

The app can be configured to use a non-Russian TMDB language, for example Ukrainian, but some CUB-backed surfaces still display CUB-provided Russian metadata. Resolving those cards through the existing TMDB wrapper lets them use the configured `tmdb_lang` without changing the CUB list endpoints.

## Details

- Applies the enrichment to digital releases.
- Applies the same enrichment to the feed.
- Falls back to the original CUB card if the item has no `imdb_id` or TMDB resolution fails.
- Preserves selected CUB metadata such as IMDb/KP ratings and release quality.
- Preserves feed episode data so episode cards keep their still image and episode context.
- Limits concurrent TMDB lookups to avoid firing all requests at once.
- Uses the existing `Api.sources.tmdb.get` cache path.

## Validation

```sh
npm run test -- --run
```

Result: 46 tests passed.
