### PR TITLE
Fix notification posters using TMDB card poster

### DIFF
--- a/src/interaction/notice/notice.js
+++ b/src/interaction/notice/notice.js
@@ -93,7 +93,7 @@ class Notice{
         items.forEach(element => {
             try{
                 let item = Template.get('notice_card',{})
-                let icon = element.poster || element.icon || element.img
+                let icon = element.poster || element.card?.poster_path || element.icon || element.img
 
                 let author_data = {}
                 let author_html
@@ -140,7 +140,7 @@ class Notice{
                     else this.listener.send('select',{display: element.display || this.display, element})
                 }).on('visible',()=>{
                     if(icon){
-                        icon = translate(icon)
+                        if(Arrays.isObject(icon)) icon = icon[Lampa.Storage.get('tmdb_lang')] || element.card?.poster_path
 
                         if(icon && icon.indexOf('http') == -1) icon = TMDB.image('t/p/w300/'+icon)
 


### PR DESCRIPTION
Prioritization of the `poster_path` parameter from TMDB for images in notifications has been implemented for languages that do not receive localized posters from CUB. The default parameters for the CUB remain the same for the other languages like `ru,en,uk.`

<img width="827" height="474" alt="Untitled" src="https://github.com/user-attachments/assets/8073926b-bee5-4b47-8b75-b1ed2894859d" />
