### PR TITLE
Pass card info to Android player

### DIFF
--- a/src/core/android.js
+++ b/src/core/android.js
@@ -69,6 +69,8 @@ function openTorrent(SERVER){
 }
 
 function openPlayer(link, data){
+    if (data) data.card = resolveCard(data)
+
     let updateTimeline = function(elem){
         if(elem.timeline){
             let new_timeline = Lampa.Timeline.view(elem.timeline.hash)
@@ -172,6 +174,16 @@ function checkVersion(needVersion, silent=false){
             return false
         }
     } else return false
+}
+
+function resolveCard(data) {
+    if (data && (data.card || data.movie)) return data.card || data.movie
+
+    let activity = Activity.active()
+
+    if (activity && (activity.card || activity.movie)) return activity.card || activity.movie
+
+    return null
 }
 
 export default {


### PR DESCRIPTION
Introduced a new `resolveCard(data)` utility function to simplify resolving `card` or `movie` objects from data or the active activity. Integrated this function into `openPlayer` for enhanced functionality. Updated `openTorrent` to handle dynamic anchor clicks and refined `checkVersion` logic. Exported `resolveCard` as part of the default module.