### PR TITLE
Fix episode navigation across seasons and surface season in player UI

### DIFF
--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -1179,6 +1179,17 @@ function getUrlQuality(quality, set_better = true){
     return url
 }
 
+function playTitle(data){
+    if(!(data.season > 0)) return data.title
+
+    let title = Lang.translate('torrent_serial_season') + ' ' + data.season
+
+    if(data.episode) title += ' · ' + Lang.translate('torrent_serial_episode') + ' ' + data.episode
+    if(data.title)   title += ' · ' + data.title
+
+    return title
+}
+
 /**
  * Запустить плеер
  * @doc
@@ -1228,7 +1239,7 @@ function play(data){
 
                 skipHide()
 
-                Playlist.url(data.url)
+                Playlist.url(data.url, data.path)
 
                 if(data.playlist && data.playlist.length) Playlist.set(data.playlist)
                 else Playlist.set(Playlist.get()) //надо повторно отправить, а то после рекламы неправильно показывает
@@ -1246,7 +1257,7 @@ function play(data){
                 if(data.subtitles) Video.customSubs(data.subtitles)
                 if(data.voiceovers) Panel.setTracks(data.voiceovers)
 
-                Info.set('name',data.title)
+                Info.set('name', playTitle(data))
 
                 stat(data)
 

--- a/src/interaction/player/panel.js
+++ b/src/interaction/player/panel.js
@@ -1414,10 +1414,17 @@ function quality(qs, url){
  * @param {{position:integer, playlist:[{title:string, url:string}]}} e 
  */
 function showNextEpisodeName(e){
-    if(e.playlist[e.position + 1]){
-        elems.episode.text(e.playlist[e.position + 1].title).toggleClass('hide',false)
-    }
-    else elems.episode.toggleClass('hide',true)
+    let next = e.playlist[e.position + 1]
+
+    if(!next) return elems.episode.toggleClass('hide',true)
+
+    let label = Lang.translate('player_next_episode') + ': '
+
+    if(next.season > 0) label += Lang.translate('torrent_serial_season') + ' ' + next.season
+    if(next.episode)    label += (next.season > 0 ? ' · ' : '') + Lang.translate('torrent_serial_episode') + ' ' + next.episode
+    if(!(next.season > 0) && !next.episode) label += next.title
+
+    elems.episode.text(label).toggleClass('hide',false)
 }
 
 /**

--- a/src/interaction/player/playlist.js
+++ b/src/interaction/player/playlist.js
@@ -5,22 +5,57 @@ import Lang from '../../core/lang'
 
 let listener = Subscribe()
 let current  = ''
+let currentPath = ''
 let playlist = []
 let position = 0
+
+// url мутирует в момент клика (caps-параметры, &play/&preload),
+// поэтому сопоставляем по стабильному path, с откатом на url
+function matches(item){
+    if(currentPath && item.path) return item.path == currentPath
+
+    return item.url == current
+}
+
+// playlist уходит во внешние плееры, поэтому для окна выбора
+// возвращаем копию с разделителями, не трогая исходный массив
+function withSeasonSeparators(items){
+    if(!items.some(item => item.season > 0)) return items
+
+    let display = []
+    let lastSeason
+
+    items.forEach(item => {
+        let season = item.season || 0
+
+        if(season !== lastSeason){
+            if(season) display.push({
+                separator: true,
+                title: Lang.translate('torrent_serial_season') + ' ' + season
+            })
+
+            lastSeason = season
+        }
+
+        display.push(item)
+    })
+
+    return display
+}
 
 /**
  * Показать плейлист
  */
 function show(){
     if(!playlist.length) return
-    
+
     active()
 
     let enabled = Controller.enabled()
 
     Select.show({
         title: Lang.translate('player_playlist'),
-        items: playlist,
+        items: withSeasonSeparators(playlist),
         onSelect: (a)=>{
             Controller.toggle(enabled.name)
 
@@ -41,7 +76,7 @@ function show(){
  */
 function active(){
     playlist.forEach(element => {
-        element.selected = element.url == current
+        element.selected = matches(element)
 
         if(element.selected) position = playlist.indexOf(element)
     })
@@ -95,7 +130,7 @@ function set(p){
     playlist = p
 
     playlist.forEach((l,i)=>{
-        if(l.url == current) position = i
+        if(matches(l)) position = i
     })
 
     listener.send('set',{playlist,position})
@@ -110,11 +145,14 @@ function set(p){
 }
 
 /**
- * Установить текуший урл
- * @param {string} u 
+ * Установить текущий урл
+ * @param {string} u урл
+ * @param {string} [p] путь файла внутри торрента (стабильный ключ)
  */
-function url(u){
+function url(u, p){
     current = u
+
+    currentPath = p || ''
 }
 
 

--- a/src/lang/be.js
+++ b/src/lang/be.js
@@ -795,6 +795,7 @@ export default {
     player_size_v130_descr: 'Павялічыць відэа на 130%',
     player_video_size: 'Памер відэа',
     player_playlist: 'Плэйліст',
+    player_next_episode: 'Далей',
     player_error_one: 'Не атрымалася дэкадаваць відэа',
     player_error_two: 'Відэа не знойдзена ці пашкоджана',
     player_start_from: 'Працягнуць прагляд з',

--- a/src/lang/bg.js
+++ b/src/lang/bg.js
@@ -792,6 +792,7 @@ export default {
     player_size_v130_descr: 'Увеличи видеото с 130%',
     player_video_size: 'Видео размер',
     player_playlist: 'Плейлиста',
+    player_next_episode: 'Напред',
     player_error_one: 'Неуспешно декодиране на видео',
     player_error_two: 'Видеото не е намерено или повредено',
     player_start_from: 'Продължете да разглеждате от',

--- a/src/lang/cs.js
+++ b/src/lang/cs.js
@@ -905,6 +905,7 @@ export default {
     player_size_v130_descr: "Zvětšit video na 130%",
     player_video_size: "Velikost videa",
     player_playlist: "Playlist",
+    player_next_episode: 'Další',
     player_error_one: "Nepodařilo se dekódovat video",
     player_error_two: "Video nebylo nalezeno nebo je poškozeno",
     player_start_from: "Pokračovat ve sledování od",

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -792,6 +792,7 @@ export default {
     player_size_v130_descr: 'Enlarge video by 130%',
     player_video_size: 'Video size',
     player_playlist: 'Playlist',
+    player_next_episode: 'Next',
     player_error_one: 'Failed to decode video',
     player_error_two: 'Video not found or corrupted',
     player_start_from: 'Continue browsing from',

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -792,6 +792,7 @@ export default {
     player_size_v130_descr: 'Agrandir verticalement de 130%',
     player_video_size: 'Taille de la vidéo',
     player_playlist: 'Playlist',
+    player_next_episode: 'Suivant',
     player_error_one: 'Échec du décodage vidéo',
     player_error_two: 'Vidéo non trouvée ou corrompue',
     player_start_from: 'Reprendre le visionnage à',

--- a/src/lang/he.js
+++ b/src/lang/he.js
@@ -750,6 +750,7 @@ export default {
     player_size_v130_descr: 'הגדל את הווידאו ב-130%',
     player_video_size: 'גודל וידאו',
     player_playlist: 'רשימת השמעה',
+    player_next_episode: 'הבא',
     player_error_one: 'אין אפשרות לפענח את הווידאו',
     player_error_two: 'וידאו לא נמצא או פגום',
     player_start_from: 'המשך לעיין מ',

--- a/src/lang/pl.js
+++ b/src/lang/pl.js
@@ -955,6 +955,7 @@ export default {
     player_size_v130_descr:  'Powiększenie wideo o 130%',
     player_video_size:  'Rozmiar wideo',
     player_playlist:  'Playlista',
+    player_next_episode: 'Dalej',
     player_error_one:  'Nie udało się zdekodować wideo',
     player_error_two:  'Wideo nie znalezione lub uszkodzone',
     player_start_from:  'Kontynuuj od',

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -791,6 +791,7 @@ export default {
     player_size_v130_descr: 'Aumente o vídeo em 130%',
     player_video_size: 'Tamanho do vídeo',
     player_playlist: 'Lista de reprodução',
+    player_next_episode: 'A seguir',
     player_error_one: 'Falha ao descodificar vídeo',
     player_error_two: 'Vídeo não encontrado ou corrompido',
     player_start_from: 'Continuar navegando de',

--- a/src/lang/ro.js
+++ b/src/lang/ro.js
@@ -792,6 +792,7 @@ export default {
     player_size_v130_descr: 'Mărește video cu 130% pe verticală',
     player_video_size: 'Dimensiune video',
     player_playlist: 'Listă de redare',
+    player_next_episode: 'În continuare',
     player_error_one: 'Eșec la decodarea video',
     player_error_two: 'Video negăsit sau corupt',
     player_start_from: 'Continuă vizionarea de la',

--- a/src/lang/ru.js
+++ b/src/lang/ru.js
@@ -966,6 +966,7 @@ export default {
     player_size_v130_descr: 'Увеличить видео на 130%',
     player_video_size: 'Размер видео',
     player_playlist: 'Плейлист',
+    player_next_episode: 'Далее',
     player_error_one: 'Не удалось декодировать видео',
     player_error_two: 'Видео не найдено или повреждено',
     player_start_from: 'Продолжить просмотр с',

--- a/src/lang/uk.js
+++ b/src/lang/uk.js
@@ -757,6 +757,7 @@ export default {
     player_size_v130_descr: 'Збільшити відео на 130%',
     player_video_size: 'Розмір відео',
     player_playlist: 'Плейлист',
+    player_next_episode: 'Далі',
     player_error_one: 'Не вдалося декодувати відео',
     player_error_two: 'Відео не знайдено або пошкоджено',
     player_start_from: 'Продовжити перегляд з',

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -755,6 +755,7 @@ export default {
     player_size_v130_descr: '将视频放大 130%',
     player_video_size: '视频大小',
     player_playlist: '播放列表',
+    player_next_episode: '接下来',
     player_error_one: '视频解码失败',
     player_error_two: '视频未找到或损坏',
     player_start_from: '继续浏览',


### PR DESCRIPTION
## Motivation

Better support for torrent releases that pack **multiple seasons into a single playlist**. The player side was only designed for one season per playlist, which broke navigation:

- matching of the currently playing item used only the stream URL, which is unstable — it can be mutated at click time (extra query params) or collide between seasons;
- when the URL matched nothing, the position stayed at `0`, so next/prev (and auto-next at episode end) jumped to **the first episode of season 1** instead of the next episode of the current season;
- the playlist window showed all episodes of all seasons as one flat list with no season separation.

## Changes

- **Match by stable path**: the playing item is matched by the torrent-internal file `path`, falling back to URL for playlists without paths (online sources, IPTV).
- **Season grouping**: the player playlist window groups episodes by season with separator headers (a display-only copy — the raw playlist sent to external players is untouched).
- **Player title** now shows season and episode numbers: `Season 2 · Episode 5 · Name`.
- **Next-episode caption** under the progress bar shows a short `Next: Season N · Episode M` label using a new `player_next_episode` translation key (added for all 12 languages), with a fallback to the episode title for non-serial playlists.

## Screenshots

<img width="1800" height="981" alt="Screenshot From 2026-07-26 16-05-20" src="https://github.com/user-attachments/assets/49afb421-b51d-47c1-ae0d-f2a7e4313857" />
<img width="1800" height="981" alt="Screenshot From 2026-07-26 16-05-14" src="https://github.com/user-attachments/assets/d414e467-156e-4a87-8e77-6bc58514d6fa" />
<img width="1800" height="981" alt="Screenshot From 2026-07-26 16-05-06" src="https://github.com/user-attachments/assets/74837158-e43c-491d-b60d-948a53b7cb3a" />
<img width="1800" height="981" alt="Screenshot From 2026-07-26 16-04-59" src="https://github.com/user-attachments/assets/50003cab-2dbb-4341-8535-d1843d9ea19c" />

## Testing

- Torrent with 2+ seasons in one playlist: open season 2, episode 1 → next goes to season 2 episode 2 (not season 1);
- playlist window shows season separators;
- regression: online sources / IPTV playlists (no `path`) still navigate by URL.
