### PR TITLE
Improve audio track labels and show dubbing studio

### DIFF
--- a/spec/player_track_info.spec.js
+++ b/spec/player_track_info.spec.js
@@ -1,0 +1,41 @@
+import {describe, expect, test} from 'vitest'
+import {channelLayout, codecName, languageCode, languageName, tracksFromFfprobe} from '../src/interaction/player/track_info'
+
+describe('Player audio track info', () => {
+    test('formats the raw Tizen values like Kodi', () => {
+        let translate = key=>key == 'filter_lang_uk' ? 'Українська' : key
+
+        expect(languageCode('ukr')).toBe('uk')
+        expect(languageName('ukr', translate, 'Невідомо')).toBe('Українська')
+        expect(codecName('audio/x-ac3')).toBe('Dolby Digital')
+        expect(channelLayout(6)).toBe('5.1')
+    })
+
+    test('uses Kodi-style names for common codecs', () => {
+        expect(codecName('eac3')).toBe('Dolby Digital+')
+        expect(codecName('A_DTS')).toBe('DTS')
+        expect(codecName('truehd_atmos')).toBe('TrueHD · Atmos')
+        expect(channelLayout('stereo')).toBe('2.0')
+    })
+
+    test('takes the voice studio description from the MKV track title', () => {
+        expect(tracksFromFfprobe([{
+            index: 11,
+            codec_type: 'audio',
+            codec_name: 'ac3',
+            channels: 6,
+            tags: {language: 'ukr', title: 'DniproFilm'}
+        }])).toEqual([{
+            language: 'ukr',
+            label: 'DniproFilm',
+            extra: {channels: 6, fourCC: 'ac3'}
+        }])
+    })
+
+    test('does not show generic container handler names as a studio', () => {
+        expect(tracksFromFfprobe([{
+            codec_type: 'audio',
+            tags: {language: 'eng', handler_name: 'SoundHandler'}
+        }])[0].label).toBe('')
+    })
+})

--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -26,6 +26,7 @@ import Footer from './player/footer'
 import Segments from './player/segments'
 import ExternalPlayer from '../core/externalPlayer.js'
 import InfusePlayer from '../core/infusePlayer.js'
+import {tracksFromFfprobe} from './player/track_info'
 
 let html
 let listener = Subscribe()
@@ -1197,6 +1198,15 @@ function play(data){
     console.log('Player','url:',data.url)
 
     if(data.torrent_hash && Torserver.gstWork()) data.hls_manifest_timeout = 60000
+
+    if(data.ffprobe && !Arrays.isArray(data.translate)){
+        let tracks = tracksFromFfprobe(data.ffprobe)
+
+        if(tracks.length){
+            if(!data.translate || typeof data.translate !== 'object') data.translate = {}
+            if(!data.translate.tracks) data.translate.tracks = tracks
+        }
+    }
 
     if(data.quality){
         if(Arrays.getKeys(data.quality).length == 1) delete data.quality

--- a/src/interaction/player/panel.js
+++ b/src/interaction/player/panel.js
@@ -14,6 +14,7 @@ import TV from './iptv'
 import Footer from './footer'
 import Playlist from './playlist'
 import Segments from './segments'
+import {languageName, codecName, channelLayout} from './track_info'
 
 let html
 let listener = Subscribe()
@@ -352,20 +353,22 @@ function init(){
     elems.tracks.on('hover:enter',(e)=>{
         if(tracks.length){
             tracks.forEach((element, p) => {
-                let name = []
+                let details = []
                 let from = translates.tracks && Arrays.isArray(translates.tracks) && translates.tracks[p] ? translates.tracks[p] : element
+                let extra = Object.assign({}, element.extra || {}, from.extra || {})
+                let language = languageName(from.language || from.name || element.language || element.name, Lang.translate, Lang.translate('player_unknown'))
+                let description = from.label || element.label || ''
+                let codec = codecName(extra.codecName || extra.codec || extra.fourCC)
+                let channels = channelLayout(extra.channel_layout || extra.channels)
 
-                name.push(p + 1)
-                name.push(normalName(from.language || from.name || Lang.translate('player_unknown')))
+                details.push((p + 1) + '. ' + normalName(language))
 
-                if(from.label) name.push(normalName(from.label))
+                if(codec) details.push(codec + (channels ? ' ' + channels : ''))
+                else if(channels) details.push(channels)
 
-                if(from.extra){
-                    if(from.extra.channels) name.push(from.extra.channels + ' Ch')
-                    if(from.extra.fourCC) name.push(from.extra.fourCC)
-                }
+                if(description && normalName(description).toLowerCase() !== normalName(language).toLowerCase()) details.push(normalName(description))
                 
-                element.title = name.join(' / ')
+                element.title = details.join(' · ')
             })
 
             let enabled = Controller.enabled().name
@@ -1101,7 +1104,7 @@ function isTV(){
 }
 
 function normalName(name){
-    return name.replace(/^[0-9]+(\.)?([\t ]+)?/,'').replace(/\s#[0-9]+/,'')
+    return String(name || '').replace(/^[0-9]+(\.)?([\t ]+)?/,'').replace(/\s#[0-9]+/,'')
 }
 
 /**

--- a/src/interaction/player/track_info.js
+++ b/src/interaction/player/track_info.js
@@ -1,0 +1,109 @@
+const language_codes = {
+    ara: 'ar', arm: 'hy', hye: 'hy', aze: 'az', bel: 'be', bul: 'bg', chi: 'zh', zho: 'zh',
+    cze: 'cs', ces: 'cs', dan: 'da', dut: 'nl', nld: 'nl', eng: 'en', est: 'et', fin: 'fi',
+    fre: 'fr', fra: 'fr', geo: 'ka', kat: 'ka', ger: 'de', deu: 'de', gre: 'el', ell: 'el',
+    heb: 'he', hin: 'hi', hun: 'hu', ice: 'is', isl: 'is', ita: 'it', jpn: 'ja', kaz: 'kk',
+    kor: 'ko', lav: 'lv', lit: 'lt', mac: 'mk', mkd: 'mk', nor: 'no', per: 'fa', fas: 'fa',
+    pol: 'pl', por: 'pt', rum: 'ro', ron: 'ro', rus: 'ru', slo: 'sk', slk: 'sk', slv: 'sl',
+    spa: 'es', swe: 'sv', tur: 'tr', ukr: 'uk', uzb: 'uz', vie: 'vi'
+}
+
+const codec_names = {
+    aac: 'AAC', aac_lc: 'AAC-LC', aac_ssr: 'AAC-SSR', aac_ltp: 'AAC-LTP',
+    he_aac: 'HE-AAC', he_aac_v2: 'HE-AACv2', aac_latm: 'AAC',
+    ac3: 'Dolby Digital', dolbydigital: 'Dolby Digital',
+    eac3: 'Dolby Digital+', eac3_ddp_atmos: 'Dolby Digital+ · Atmos',
+    dca: 'DTS', dts: 'DTS', dtshd_hra: 'DTS-HD HRA', dtshd_ma: 'DTS-HD MA',
+    dtsma: 'DTS-HD MA', dtshd_ma_x: 'DTS-HD MA · DTS:X',
+    dtshd_ma_x_imax: 'DTS-HD MA · DTS:X IMAX',
+    truehd: 'TrueHD', truehd_atmos: 'TrueHD · Atmos',
+    flac: 'FLAC', mp1: 'MP1', mp2: 'MP2', mp3: 'MP3', mp3float: 'MP3',
+    opus: 'Opus', vorbis: 'Vorbis', ogg: 'OGG', alac: 'ALAC', ape: 'APE',
+    pcm: 'PCM', pcm_bluray: 'PCM', pcm_s16le: 'PCM', pcm_s24le: 'PCM',
+    wav: 'WAV', wavpack: 'WavPack', wmapro: 'WMA Pro', wmav2: 'WMA'
+}
+
+function languageCode(value){
+    let code = String(value || '').trim().toLowerCase().replace(/_/g, '-').split('-')[0]
+
+    if(code == 'ua') code = 'uk'
+
+    return language_codes[code] || code
+}
+
+function languageName(value, translate, unknown){
+    let source = String(value || '').trim()
+
+    if(!source) return unknown
+
+    let code = languageCode(source)
+
+    if(/^[a-z]{2}$/.test(code)){
+        let key = 'filter_lang_' + code
+        let name = translate(key)
+
+        if(name && name !== key) return name
+    }
+
+    return source.toUpperCase() == source && source.length <= 3 ? source.toUpperCase() : source
+}
+
+function codecName(value){
+    let source = String(value || '').trim()
+
+    if(!source) return ''
+
+    let key = source.toLowerCase()
+        .split(';')[0]
+        .replace(/^audio\/(?:x-)?/, '')
+        .replace(/^a_/, '')
+        .replace(/[ .-]+/g, '_')
+
+    return codec_names[key] || source.replace(/^audio\/(?:x-)?/i, '').toUpperCase()
+}
+
+function channelLayout(value){
+    if(value === undefined || value === null || value === '') return ''
+
+    if(typeof value == 'string' && !/^\d+(?:\.\d+)?(?:\s*ch)?$/i.test(value.trim())){
+        return value.replace(/\s*\(side\)/i, '').replace(/^mono$/i, '1.0').replace(/^stereo$/i, '2.0')
+    }
+
+    let channels = parseInt(value)
+    let layouts = {1: '1.0', 2: '2.0', 3: '2.1', 4: '4.0', 5: '5.0', 6: '5.1', 7: '6.1', 8: '7.1'}
+
+    return layouts[channels] || (channels ? channels + ' Ch' : '')
+}
+
+function usefulDescription(tags){
+    let title = tags && (tags.title || tags.TITLE)
+    let handler = tags && (tags.handler_name || tags.HANDLER_NAME)
+    let description = String(title || handler || '').trim()
+
+    return /^(sound|audio)\s*handler$/i.test(description) ? '' : description
+}
+
+function tracksFromFfprobe(streams){
+    if(!Array.isArray(streams)) return []
+
+    return streams.filter(stream=>stream && stream.codec_type == 'audio').map(stream=>{
+        let tags = stream.tags || {}
+
+        return {
+            language: tags.language || tags.LANGUAGE || '',
+            label: usefulDescription(tags),
+            extra: {
+                channels: stream.channel_layout || stream.channels,
+                fourCC: stream.codec_name || stream.codec_long_name || ''
+            }
+        }
+    })
+}
+
+export {
+    languageCode,
+    languageName,
+    codecName,
+    channelLayout,
+    tracksFromFfprobe
+}


### PR DESCRIPTION
## Summary

- localize ISO 639 audio language codes with Lampa's existing language strings
- normalize codec names and channel layouts using Kodi-style labels
- enrich torrent audio tracks from existing `ffprobe` metadata, including the MKV track title that commonly identifies the dubbing studio
- hide generic container descriptions such as `SoundHandler`

## Why

Audio tracks on TV platforms were displayed as raw technical values such as:

```text
11 / ukr / 6 Ch / audio/x-ac3
```

This change presents the same information in a readable form while preserving the track number and selection behavior:

```text
11. Українська · Dolby Digital 5.1 · DniproFilm
```

The studio/voice-over description is shown only when the source container provides it in the track metadata. No external metadata lookup is added.

## Impact

The change affects audio-track labels only. Existing platform-specific track selection remains unchanged. Browser playback still depends on the browser or HLS player exposing selectable audio tracks.

## Validation

- `npm run test -- --run` — 55 tests passed
- added focused tests for language, codec, channel-layout, and MKV title normalization
- manually verified with a multi-audio torrent in Lampa
