### PR TITLE
fix(torrent): ссылка в плейлисте расходится с той, что играет плеер

### DIFF
--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -408,7 +408,9 @@ function list(items, params){
         playlist.push({
             title: element.title,
             subtitle: element.episode ? Lang.translate('torrent_serial_episode') + ': ' + element.episode : '',
-            url: element.url,
+            // Плеер ищет текущую серию по url, а перед запуском меняет
+            // &preload на &play — копия должна быть в том же виде
+            url: element.url.replace('&preload', '&play'),
             season: element.season,
             episode: element.episode,
             path: element.path,


### PR DESCRIPTION
В плеере название следующей серии, кнопка перехода и автопереход по окончании
указывают не на ту серию — в свежем плеере всегда на вторую запись плейлиста.
После одного переключения через плейлист чинится само.

Началось похоже с b12c8eb (20 июня), где в плейлист торрентов вместо самого объекта стали класть
копию полей:

```diff
- playlist.push(element)
+ playlist.push({ title: element.title, url: element.url, ... })
```

Плеер опознаёт текущую серию, сравнивая url с записями плейлиста, а перед
запуском меняет в объекте `&preload` на `&play`. Раньше замена доезжала и до
записи плейлиста, поэтому совпадало. Теперь копия остаётся с `&preload`,
совпадений нет, и `position` сохраняет прежнее значение — в свежем плеере `0`.

Предлагаю класть ссылку сразу в том виде, в каком её использует плеер.

Проверено на webOS с настоящей раздачей, играл файл 4 из 8: позиция `0` → `3`,
следующая серия — вторая → пятая.
