### PR TITLE
Add media-rich TorrServer preload screen

### DIFF
--- a/spec/media_loading.spec.js
+++ b/spec/media_loading.spec.js
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'vitest'
+import {languageCode, selectLogo} from '../src/interaction/media_loading_data'
+
+describe('Media loading artwork', () => {
+    let logos = [
+        {iso_639_1: null, file_path: '/neutral.png'},
+        {iso_639_1: 'en', file_path: '/english.png'},
+        {iso_639_1: 'uk', file_path: '/ukrainian.png'}
+    ]
+
+    test('normalizes regional TMDB language codes', () => {
+        expect(languageCode('uk-UA')).toBe('uk')
+        expect(languageCode('EN_us')).toBe('en')
+    })
+
+    test('prefers the configured language logo', () => {
+        expect(selectLogo(logos, 'uk-UA').file_path).toBe('/ukrainian.png')
+    })
+
+    test('falls back to English and then language-neutral artwork', () => {
+        expect(selectLogo(logos, 'pl').file_path).toBe('/english.png')
+        expect(selectLogo([logos[0]], 'pl').file_path).toBe('/neutral.png')
+    })
+
+    test('returns false when no logo artwork is available', () => {
+        expect(selectLogo([], 'uk')).toBe(false)
+    })
+})

--- a/src/core/api/sources/tmdb.js
+++ b/src/core/api/sources/tmdb.js
@@ -537,10 +537,12 @@ function category(params = {}, oncomplite, onerror){
 function full(params = {}, oncomplite, onerror){
     let status = new Status(9)
         status.onComplite = oncomplite
+    let image_language = (Storage.field('tmdb_lang') || 'en').split(/[-_]/)[0]
+    let image_languages = [image_language, 'en', 'null'].filter((language, index, list)=>list.indexOf(language) == index).join(',')
 
     if(Utils.dcma(params.method, params.id)) return onerror()
 
-    get(params.method+'/'+params.id+'?append_to_response=content_ratings,release_dates,external_ids,keywords,alternative_titles',params,(json)=>{
+    get(params.method+'/'+params.id+'?append_to_response=content_ratings,release_dates,external_ids,keywords,alternative_titles,images&include_image_language='+image_languages,params,(json)=>{
         json.source = 'tmdb'
 
         if(json.external_ids){

--- a/src/interaction/loading.js
+++ b/src/interaction/loading.js
@@ -1,10 +1,12 @@
 import Controller from '../core/controller'
 import Lang from '../core/lang'
 import DeviceInput from './device_input'
+import MediaLoading from './media_loading'
 
 let callback_cancel,
     controller_enabled,
     loader,
+    media_loader,
     timer
 
 /**
@@ -13,19 +15,34 @@ let callback_cancel,
  * @param {string} text - текст загрузки
  * @returns {void}
  */
-function start(on_cancel, text){
+function start(on_cancel, text, options = {}){
     callback_cancel = on_cancel
 
     controller_enabled = Controller.enabled().name
 
-    loader = $(`<div class="loading-layer">
-        <div class="loading-layer__box">
-            <div class="loading-layer__text">${Lang.translate('loading')}</div>
-            <div class="loading-layer__ico"></div>
-        </div>
-    </div>`)
+    if(media_loader){
+        media_loader.destroy()
+        media_loader = false
+    }
 
-    if(text) loader.find('.loading-layer__text').text(text)
+    if(options.media){
+        media_loader = MediaLoading.create()
+        loader = media_loader.render().addClass('media-loading--standalone')
+
+        media_loader.set(options.media)
+        media_loader.update(options.progress || 0, text)
+        media_loader.show()
+    }
+    else{
+        loader = $(`<div class="loading-layer">
+            <div class="loading-layer__box">
+                <div class="loading-layer__text">${Lang.translate('loading')}</div>
+                <div class="loading-layer__ico"></div>
+            </div>
+        </div>`)
+
+        if(text) loader.find('.loading-layer__text').text(text)
+    }
 
     loader.on('click',(e)=>{
         if(DeviceInput.canClick(e.originalEvent)) cancel()
@@ -33,9 +50,14 @@ function start(on_cancel, text){
 
     clearTimeout(timer)
 
-    timer = setTimeout(()=>{
+    if(options.media){
         $('body').append(loader)
-    },500)
+    }
+    else{
+        timer = setTimeout(()=>{
+            $('body').append(loader)
+        },500)
+    }
     
 
     toggle()
@@ -74,7 +96,13 @@ function cancel(){
  * @returns {void}
  */
 function stop(){
-    if(loader) loader.remove()
+    if(media_loader){
+        media_loader.destroy()
+        media_loader = false
+    }
+    else if(loader) loader.remove()
+
+    loader = false
 
     clearTimeout(timer)
 
@@ -87,11 +115,18 @@ function stop(){
  * @returns {void}
  */
 function setText(text){
-    if(loader) loader.find('.loading-layer__text').text(text)
+    if(media_loader) media_loader.update(0, text)
+    else if(loader) loader.find('.loading-layer__text').text(text)
+}
+
+function setProgress(progress, detail){
+    if(media_loader) media_loader.update(progress, detail)
+    else setText(Math.round(progress) + '%' + (detail ? ' - ' + detail : ''))
 }
 
 export default {
     start,
     stop,
-    setText
+    setText,
+    setProgress
 }

--- a/src/interaction/media_loading.js
+++ b/src/interaction/media_loading.js
@@ -1,0 +1,135 @@
+import Api from '../core/api/api'
+import Storage from '../core/storage/storage'
+import {selectLogo} from './media_loading_data'
+
+function imageUrl(path, size){
+    if(!path) return ''
+    if(/^(https?:)?\/\//i.test(path) || /^(data|blob):/i.test(path)) return path
+
+    return Api.img(path, size)
+}
+
+function mediaData(data = {}){
+    let card = data.card || data.movie || data
+    let logo = selectLogo(card.images && card.images.logos, Storage.field('tmdb_lang'))
+
+    return {
+        title: data.first_title || card.title || card.name || data.title || '',
+        background: imageUrl(card.backdrop_path, 'original') || card.background_image || card.background || data.background || data.img || data.thumbnail || '',
+        logo: logo ? imageUrl(logo.file_path, 'w500') : card.logo || data.logo || ''
+    }
+}
+
+function createMark(media, class_name){
+    let mark = $('<div class="media-loading__mark-content '+class_name+'"></div>')
+
+    if(media.logo){
+        mark.append($('<img class="media-loading__logo" alt="">').attr('src', media.logo))
+    }
+    else{
+        mark.append($('<div class="media-loading__title"></div>').text(media.title))
+    }
+
+    return mark
+}
+
+function create(){
+    let html = $(`<div class="media-loading hide">
+        <img class="media-loading__backdrop" alt="">
+        <div class="media-loading__shade"></div>
+        <div class="media-loading__content">
+            <div class="media-loading__mark">
+                <div class="media-loading__mark-background"></div>
+                <div class="media-loading__mark-fill"></div>
+            </div>
+            <div class="media-loading__status">
+                <span class="media-loading__peers">
+                    <svg class="media-loading__peers-icon" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3v12m0 0 5-5m-5 5-5-5M5 19h14"></path>
+                    </svg>
+                    <span class="media-loading__peers-value"></span>
+                </span>
+                <span class="media-loading__separator media-loading__peers-separator"></span>
+                <span class="media-loading__speed"></span>
+                <span class="media-loading__separator media-loading__speed-separator"></span>
+                <span class="media-loading__percent">0%</span>
+            </div>
+        </div>
+    </div>`)
+    let media = {}
+    let hide_timer
+
+    function set(data){
+        media = mediaData(data)
+
+        let backdrop = html.find('.media-loading__backdrop')
+        let background = html.find('.media-loading__mark-background')
+        let fill = html.find('.media-loading__mark-fill')
+
+        if(media.background) backdrop.attr('src', media.background).removeClass('hide')
+        else backdrop.attr('src', '').addClass('hide')
+
+        background.empty().append(createMark(media, 'media-loading__mark-content--background'))
+        fill.empty().append(createMark(media, 'media-loading__mark-content--foreground'))
+
+        html.toggleClass('media-loading--text', !media.logo)
+    }
+
+    function update(value, detail){
+        let progress = Math.max(0, Math.min(100, parseFloat(value) || 0))
+        let stats = typeof detail == 'object' && detail ? detail : {speed: detail}
+        let speed = stats.speed || ''
+        let active = parseInt(stats.active_peers)
+        let total = parseInt(stats.total_peers)
+        let show_peers = !isNaN(active)
+
+        html.find('.media-loading__mark-fill').css('width', progress + '%')
+        html.find('.media-loading__percent').text(Math.round(progress) + '%')
+        html.find('.media-loading__speed').text(speed).toggleClass('hide', !speed)
+        html.find('.media-loading__peers-separator').toggleClass('hide', !show_peers)
+        html.find('.media-loading__speed-separator').toggleClass('hide', !speed)
+        html.find('.media-loading__peers').toggleClass('hide', !show_peers)
+        html.find('.media-loading__peers-value').text(show_peers ? active + ' / ' + (isNaN(total) ? '—' : total) : '')
+    }
+
+    function show(data){
+        clearTimeout(hide_timer)
+
+        if(data) set(data)
+
+        html.removeClass('hide media-loading--leaving')
+    }
+
+    function hide(immediate){
+        clearTimeout(hide_timer)
+
+        if(immediate){
+            html.addClass('hide').removeClass('media-loading--leaving')
+        }
+        else{
+            html.addClass('media-loading--leaving')
+
+            hide_timer = setTimeout(()=>{
+                html.addClass('hide').removeClass('media-loading--leaving')
+            },300)
+        }
+    }
+
+    function destroy(){
+        clearTimeout(hide_timer)
+        html.remove()
+    }
+
+    return {
+        render: ()=>html,
+        set,
+        update,
+        show,
+        hide,
+        destroy
+    }
+}
+
+export default {
+    create
+}

--- a/src/interaction/media_loading_data.js
+++ b/src/interaction/media_loading_data.js
@@ -1,0 +1,24 @@
+function languageCode(value){
+    return String(value || '').toLowerCase().split(/[-_]/)[0]
+}
+
+function selectLogo(logos, language){
+    if(!Array.isArray(logos) || !logos.length) return false
+
+    let preferred = languageCode(language)
+    let ordered = [preferred, 'en', null].filter((code, index, list)=>code !== '' && list.indexOf(code) === index)
+
+    for(let i = 0; i < ordered.length; i++){
+        let code = ordered[i]
+        let logo = logos.find(item => code === null ? !item.iso_639_1 : languageCode(item.iso_639_1) === code)
+
+        if(logo && logo.file_path) return logo
+    }
+
+    return logos.find(item => item.file_path) || false
+}
+
+export {
+    languageCode,
+    selectLogo
+}

--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -256,7 +256,9 @@ function parseSubs(path, files){
 }
 
 function preload(data, run){
-    let need_preload = Torserver.ip() && data.url.indexOf(Torserver.ip()) > -1 && data.url.indexOf('&preload') > -1
+    let has_server = Torserver.ip() && data.url.indexOf(Torserver.ip()) > -1
+    let has_preload = data.url.indexOf('&preload') > -1
+    let need_preload = has_server && has_preload
 
     if(need_preload){
         let checkout
@@ -269,7 +271,7 @@ function preload(data, run){
             network.clear()
 
             Loading.stop()
-        })
+        }, '', {media: data})
 
         let update = ()=>{    
             network.timeout(2000)
@@ -277,7 +279,9 @@ function preload(data, run){
             network.silent(first ? data.url : data.url.replace('&preload', '&stat'), function (res) {
                 let pb = res.preloaded_bytes || 0,
                     ps = res.preload_size || 0,
-                    sp = res.download_speed ? Utils.bytesToSize(res.download_speed * 8, true) : '0.0'
+                    sp = res.download_speed ? Utils.bytesToSize(res.download_speed * 8, true) : '0.0',
+                    active_peers = parseInt(res.active_peers || 0),
+                    total_peers = parseInt(res.total_peers || 0)
                 
                 let progress = Math.min(100,((pb * 100) / ps ))
 
@@ -289,7 +293,11 @@ function preload(data, run){
                     run()
                 }
                 else{
-                    Loading.setText(Math.round(progress) + '%' + ' - ' + sp)
+                    Loading.setProgress(progress, {
+                        speed: sp,
+                        active_peers: active_peers,
+                        total_peers: total_peers
+                    })
                 }
             })
 
@@ -330,6 +338,7 @@ function list(items, params){
             episode: info.episode,
             title: element.path_human,
             first_title:  params.movie.name || params.movie.title,
+            card: params.movie,
             size: Utils.bytesToSize(element.length),
             url: Torserver.stream(element.path, SERVER.hash, element.id),
             torrent_hash: SERVER.hash,
@@ -407,6 +416,8 @@ function list(items, params){
 
         playlist.push({
             title: element.title,
+            first_title: params.movie.name || params.movie.title,
+            card: params.movie,
             subtitle: element.episode ? Lang.translate('torrent_serial_episode') + ': ' + element.episode : '',
             url: element.url,
             season: element.season,

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -54,6 +54,7 @@ $media_xs: 400px;
 @import 'components/info';
 @import 'components/more';
 @import 'components/loading_layer';
+@import 'components/media_loading';
 @import 'components/category';
 @import 'components/search/main';
 @import 'components/keyboard';

--- a/src/sass/components/media_loading.scss
+++ b/src/sass/components/media_loading.scss
@@ -1,0 +1,203 @@
+.media-loading{
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background-color: #050508;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+
+    &--standalone{
+        z-index: 100;
+    }
+
+    &--leaving{
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    &__backdrop{
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        opacity: 0.58;
+    }
+
+    &__shade{
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        background: linear-gradient(180deg, rgba(4,4,8,0.3) 0%, rgba(4,4,8,0.58) 60%, rgba(4,4,8,0.82) 100%);
+    }
+
+    &__content{
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        max-width: 90%;
+        text-align: center;
+    }
+
+    &__mark{
+        position: relative;
+        width: 64vw;
+        max-width: 46em;
+        height: 13em;
+        animation: mediaLoadingPulse 2s ease-in-out infinite;
+    }
+
+    &__mark-background,
+    &__mark-fill{
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        overflow: hidden;
+    }
+
+    &__mark-background{
+        right: 0;
+        opacity: 0.2;
+    }
+
+    &__mark-fill{
+        width: 0;
+        transition: width 0.18s ease-out;
+    }
+
+    &__mark-content{
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 64vw;
+        max-width: 46em;
+        height: 13em;
+    }
+
+    &__logo{
+        display: block;
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+        object-fit: contain;
+    }
+
+    &__title{
+        width: 100%;
+        color: #fff;
+        font-size: 3.6em;
+        font-weight: 700;
+        line-height: 1.08;
+        letter-spacing: -0.025em;
+        text-shadow: 0 0.08em 0.3em rgba(0,0,0,0.65);
+    }
+
+    &__status{
+        position: fixed;
+        left: 50%;
+        bottom: 6vh;
+        display: flex;
+        align-items: center;
+        min-height: 1.5em;
+        max-width: 88vw;
+        padding: 0.75em 1.35em;
+        border: 1px solid rgba(255,255,255,0.22);
+        border-radius: 2em;
+        background-color: rgba(5,5,9,0.68);
+        box-shadow: 0 0.35em 1.2em rgba(0,0,0,0.28);
+        color: rgba(255,255,255,0.72);
+        font-size: 1.05em;
+        white-space: nowrap;
+        text-shadow: 0 0.1em 0.3em #000;
+        transform: translateX(-50%);
+        backdrop-filter: blur(0.7em);
+    }
+
+    &__percent{
+        color: #fff;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__separator{
+        width: 0.22em;
+        height: 0.22em;
+        margin: 0 0.8em;
+        border-radius: 100%;
+        background-color: rgba(255,255,255,0.55);
+        flex: none;
+    }
+
+    &__peers-value{
+        color: rgba(255,255,255,0.92);
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__peers{
+        display: flex;
+        align-items: center;
+    }
+
+    &__peers-icon{
+        width: 1.15em;
+        height: 1.15em;
+        margin-right: 0.45em;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        opacity: 0.82;
+    }
+
+    @media screen and (max-width: $media_sm){
+        &__mark,
+        &__mark-content{
+            width: 82vw;
+            height: 10em;
+        }
+
+        &__title{
+            font-size: 2.4em;
+        }
+
+        &__status{
+            bottom: 4vh;
+            padding: 0.65em 1em;
+            font-size: 0.9em;
+        }
+
+        &__separator{
+            margin: 0 0.55em;
+        }
+    }
+}
+
+@keyframes mediaLoadingPulse{
+    0%, 100%{
+        transform: scale(1);
+    }
+
+    50%{
+        transform: scale(1.035);
+    }
+}


### PR DESCRIPTION
## Summary

- add a full-screen, media-rich loading experience while TorrServer preloads a selected file
- use the TMDB backdrop and localized logo, falling back to the localized title when no logo is available
- fill the logo/title from left to right using the real TorrServer preload percentage
- show active/total peers, download speed, and percentage in a compact status pill

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/4e52090c-2699-46f1-9567-8b71b988b792" />

## Why

The current TorrServer preload UI only replaces the generic loading text with a percentage and speed. It does not provide media context, and its progress is visually disconnected from the selected title.

This change keeps the existing preload and cancellation flow, but adds an optional media mode to the loading layer. Non-media loading callers retain the existing loader.

## Implementation

- append TMDB image data using the configured language, English, and language-neutral fallbacks
- pass the selected movie/card metadata into torrent entries and playlists
- read `active_peers`, `total_peers`, `download_speed`, `preloaded_bytes`, and `preload_size` from TorrServer status responses
- add isolated logo-selection helpers and unit coverage
- add responsive Sass for TV and smaller screens

## Validation

- `node node_modules/vitest/vitest.mjs --run` — 54 tests passed
- `node node_modules/sass/sass.js src/sass/app.scss /tmp/lampa-pr-app.css` — Sass compiled and included the new media-loading selectors
- `node node_modules/gulp/bin/gulp.js build_source` — Rollup application bundle built successfully
- tested against a live TorrServer/Lampa setup, including Media Station X on TV
