### PR TITLE
fix(player): call Video.volume from volume slider

### DIFF
--- a/src/interaction/player/panel.js
+++ b/src/interaction/player/panel.js
@@ -163,7 +163,7 @@ function init(){
         Html.elem('volume').find('.player-panel__volume-range').val(Storage.get('player_volume','1')).on('input',function(){
             listener.send('change_volume',{volume: $(this).val()})
 
-            Video.changeVolume($(this).val())
+            Video.volume($(this).val())
         })
     }
 


### PR DESCRIPTION
## Summary
- After the `ai_player` video refactor, `changeVolume` was renamed to `volume` in `video.js`, but the desktop/browser volume slider in `panel.js` still called `Video.changeVolume`.
- That throws `PlayerVideo.changeVolume is not a function` when dragging the volume range input.