### PR TITLE
fix(player): фокус и отсчёт на кнопке пропуска сегмента

### DIFF
--- a/src/interaction/player.js
+++ b/src/interaction/player.js
@@ -267,8 +267,7 @@ function toggle(){
             Panel.hide()
         },
         up: ()=>{
-            if(Skip.isActive()) Skip.toggle()
-            else Panel.toggle()
+            Panel.toggle()
         },
         down: ()=>{
             Panel.toggle()

--- a/src/interaction/player/panel.js
+++ b/src/interaction/player/panel.js
@@ -15,6 +15,7 @@ import Settings from './panel/settings'
 import IptvPanel from './panel/iptv'
 import Html from './panel/html'
 import Player from '../player'
+import Skip from './skip'
 import Apex from './panel/apex'
 import Next from './panel/next'
 import listener from './panel/listener'
@@ -390,7 +391,7 @@ function addController(){
             Controller.collectionFocus(false,render())
         },
         up: ()=>{
-            Controller.toggle('player')
+            toggleUp()
         },
         down: ()=>{
             toggleButtons()
@@ -404,11 +405,7 @@ function addController(){
         gone: ()=>{
             Html.render().find('.selector').removeClass('focus')
         },
-        back: ()=>{
-            Controller.toggle('player')
-
-            hide()
-        }
+        back: toPlayer
     })
 
     Controller.add('player_panel',{
@@ -420,7 +417,7 @@ function addController(){
             } 
         },
         up: ()=>{
-            Player.playdata().iptv || Html.render().hasClass('panel--norewind') ? Controller.toggle('player') : toggleRewind()
+            Player.playdata().iptv || Html.render().hasClass('panel--norewind') ? toggleUp() : toggleRewind()
         },
         right: ()=>{
             Navigator.move('right')
@@ -434,11 +431,7 @@ function addController(){
         gone: ()=>{
             Html.render().find('.selector').removeClass('focus')
         },
-        back: ()=>{
-            Controller.toggle('player')
-
-            hide()
-        }
+        back: toPlayer
     })
 }
 
@@ -527,6 +520,32 @@ function rewind(){
  */
 function toggleRewind(){
     Controller.toggle(Player.playdata().iptv || Html.render().hasClass('panel--norewind') ? 'player_panel' : 'player_rewind')
+}
+
+/**
+ * Уйти вверх с панели: на кнопку пропуска, если она показана, иначе на плеер
+ */
+function toggleUp(){
+    if(Skip.isActive()) Skip.toggle()
+    else Controller.toggle('player')
+}
+
+/**
+ * Уйти на плеер и скрыть панель
+ */
+function toPlayer(){
+    Controller.toggle('player')
+
+    hide()
+}
+
+/**
+ * Показать панель, не переключая контроллер
+ */
+function reveal(){
+    condition.visible = true
+
+    state.start()
 }
 
 /**
@@ -632,6 +651,8 @@ export default {
     show,
     destroy,
     hide,
+    toPlayer,
+    reveal,
     canplay,
     update,
     rewind,

--- a/src/interaction/player/skip.js
+++ b/src/interaction/player/skip.js
@@ -8,6 +8,7 @@ import Player from '../player'
 import Panel from './panel'
 
 let skip_button
+let skip_line
 let skip_current  = null
 let skip_timer    = null
 let skip_text_in  = ''
@@ -16,7 +17,9 @@ let skip_is_end   = false
 let skip_phase    = ''
 
 function init(){
-    skip_button = $(`<div class="player-skip selector hide"><span class="player-skip__text"></span><svg><use xlink:href="#sprite-player-next"></use></svg></div>`)
+    skip_button = $(`<div class="player-skip selector hide"><span class="player-skip__text"></span><svg><use xlink:href="#sprite-player-next"></use></svg><div class="player-skip__progress"><div class="player-skip__progress-line"></div></div></div>`)
+
+    skip_line = skip_button.find('.player-skip__progress-line')
 
     skip_button.on('hover:enter', skipDo)
 
@@ -30,30 +33,79 @@ function init(){
                 else previewUpdate(near.starts_in)
             }
             else if(near.phase === 'inside'){
-                if(!skip_current || skip_current.segment !== near.segment || skip_phase !== 'active') active(near)
+                if(!skip_current || skip_current.segment !== near.segment || skip_phase !== 'active') active(near, e.current || 0)
+                else progressUpdate(e.current || 0)
             }
         }
         else if(skip_current) hide()
     })
 
     Player.listener.follow('destroy', destroy)
+
+    addController()
 }
 
-function toggle(){
+function addController(){
     Controller.add('player_skip',{
         toggle: ()=>{
-            if(skip_phase !== 'active') return
+            let html = Player.render()
 
             Controller.collectionSet(html)
             Controller.collectionFocus(skip_button[0], html)
         },
-        up: Panel.toggle,
+        up: ()=>{
+            if(Panel.visibleStatus()) Panel.hide()
+            else Panel.reveal()
+        },
         down: Panel.toggle,
         left: Player.toggle,
         right: Player.toggle,
         gone: ()=>{ if(skip_button) skip_button.removeClass('focus') },
         back: Player.close
     })
+}
+
+function toggle(){
+    if(!isActive()) return
+
+    Controller.toggle('player_skip')
+}
+
+function isActive(){
+    return skip_phase === 'active' && Boolean(skip_button) && !skip_button.hasClass('hide')
+}
+
+function progressSet(value, instant){
+    if(!skip_line || !skip_line.length) return
+
+    let scale = Math.max(0, Math.min(1, value))
+
+    // reflow до и после установки, иначе браузер склеит смену класса и transform в один кадр и проиграет transition
+    if(instant){
+        skip_line.addClass('player-skip__progress-line--instant')
+
+        skip_line[0].offsetWidth
+    }
+
+    skip_line.css({
+        '-webkit-transform': 'scaleX(' + scale + ')',
+        'transform': 'scaleX(' + scale + ')'
+    })
+
+    if(instant){
+        skip_line[0].offsetWidth
+
+        skip_line.removeClass('player-skip__progress-line--instant')
+    }
+}
+
+function progressUpdate(current, instant){
+    if(skip_phase !== 'active' || !skip_current) return
+
+    let seg    = skip_current.segment
+    let length = (seg.end || 0) - (seg.start || 0)
+
+    progressSet(length > 0 ? ((seg.end || 0) - current) / length : 0, instant)
 }
 
 function draw(e){
@@ -85,6 +137,8 @@ function preview(e){
 
     previewUpdate(e.starts_in)
 
+    progressSet(0, true)
+
     skip_button.removeClass('hide focus').addClass('player-skip--preview')
 }
 
@@ -94,7 +148,7 @@ function previewUpdate(seconds){
     skip_button.find('.player-skip__text').text(skip_text_in + ' ' + seconds)
 }
 
-function active(e){
+function active(e, current){
     if(!skip_button) return
 
     clearInterval(skip_timer)
@@ -107,6 +161,8 @@ function active(e){
     skip_button.removeClass('player-skip--preview')
 
     show()
+
+    progressUpdate(typeof current == 'number' ? current : e.segment.start, true)
 }
 
 function show(){
@@ -117,13 +173,15 @@ function show(){
     skip_button.find('.player-skip__text').text(skip_text_btn)
     skip_button.removeClass('hide')
 
-    if(Controller.enabled().name == 'player') Controller.toggle('player_skip')
+    if(Controller.enabled().name == 'player') toggle()
 }
 
 function hide(){
     clearInterval(skip_timer)
 
     if(skip_button) skip_button.addClass('hide').removeClass('focus player-skip--preview')
+
+    progressSet(0, true)
 
     let was  = skip_current
     skip_current = null
@@ -169,7 +227,7 @@ export default {
     previewUpdate,
     active,
     do:        skipDo,
-    isActive:  () => skip_phase === 'active' && skip_button && !skip_button.hasClass('hide'),
+    isActive,
     phase:     () => skip_phase,
     current:   () => skip_current,
     button:    () => skip_button,

--- a/src/sass/components/player/skip.scss
+++ b/src/sass/components/player/skip.scss
@@ -5,6 +5,7 @@
     padding: 0.8em 1.6em;
     border-radius: 1em;
     background-color: $bg_white;
+    overflow: hidden;
     transition: bottom 0.3s, opacity 0.2s, transform 0.2s;
 
     &__text{
@@ -19,15 +20,47 @@
         margin-left: 1em;
     }
 
+    &__progress{
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: 0.25em;
+        overflow: hidden;
+        border-bottom-left-radius: 1em;
+        border-bottom-right-radius: 1em;
+        pointer-events: none;
+    }
+
+    &__progress-line{
+        height: 100%;
+        background-color: rgba(255,255,255,0.9);
+        transform: scaleX(1);
+        transform-origin: left center;
+        transition: transform 0.25s linear;
+    }
+
+    &__progress-line--instant{
+        transition: none;
+    }
+
     &.focus{
         background-color: #fff;
         color: #000;
         box-shadow: 0 0 0 0.1em #fff;
+
+        .player-skip__progress-line{
+            background-color: rgba(0,0,0,0.4);
+        }
     }
 
     &--preview{
         opacity: 0.75;
         pointer-events: none;
+
+        .player-skip__progress{
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
## Что изменилось

- Кнопка «Пропустить» получает фокус при появлении сегмента и при нажатии вверх с панели плеера.
- Внизу кнопки идёт белая полоска остатка сегмента; в фокусе полоска становится тёмной.
- Вверх на сфокусированной кнопке показывает панель, повторное вверх скрывает её. Фокус остаётся на кнопке. Вниз по-прежнему открывает панель для навигации.

## Зачем

Без этого кнопку пропуска нельзя было выбрать пультом: контроллер не активировался, а вверх с панели уходил сразу на плеер. Полоска нужна, чтобы было видно, сколько осталось до конца сегмента, если не нажимать «Пропустить».

## Как проверить

1. Включить ручной пропуск сегментов (`player_segments_skip = user`).
2. Запустить ролик с skip-сегментом.
3. При появлении кнопки она должна быть в фокусе.
4. С панели вверх — фокус на кнопке; с кнопки вверх — панель скрывается или показывается, кнопка остаётся в фокусе.
5. Полоска уменьшается по мере проигрывания сегмента.