### PR TITLE
Bound torrent preload before playback handoff

### DIFF
--- a/spec/torrent_preload.spec.js
+++ b/spec/torrent_preload.spec.js
@@ -52,7 +52,7 @@ class FakeClock {
     }
 }
 
-function harness({android = false, selectedPlayer = 'lampa', gstWork = true, respond} = {}){
+function harness({android = false, selectedPlayer = 'lampa', launchPlayer, gstWork = true, respond} = {}){
     let clock = new FakeClock()
     let state = {
         requests: 0,
@@ -131,6 +131,8 @@ function harness({android = false, selectedPlayer = 'lampa', gstWork = true, res
         torrent_hash: 'hash'
     }
 
+    if(launchPlayer) data.launch_player = launchPlayer
+
     context.__preload(data, ()=>state.runs++)
 
     return {clock, data, state}
@@ -144,6 +146,42 @@ describe('Torrent preload handoff', () => {
         expect(result.state.requestObjects).toBe(0)
         expect(result.data.url).toContain('&play')
         expect(result.data.url).not.toContain('&preload')
+    })
+
+    test('respects an explicit inner Lampa player override', () => {
+        let result = harness({
+            android: true,
+            selectedPlayer: 'android',
+            launchPlayer: 'lampa',
+            gstWork: false,
+            respond: (url, index)=>(index ? {
+                type: 'success', value: {preloaded_bytes: 95, preload_size: 100}
+            } : {
+                type: 'success', value: {preloaded_bytes: 10, preload_size: 100}
+            })
+        })
+
+        expect(result.state.runs).toBe(0)
+        expect(result.state.requestObjects).toBe(1)
+        expect(result.data.url).toContain('&preload')
+
+        result.clock.advance(1100)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.maxInFlight).toBe(1)
+    })
+
+    test('respects an explicit external Android player override', () => {
+        let result = harness({
+            android: true,
+            selectedPlayer: 'lampa',
+            launchPlayer: 'android',
+            gstWork: true
+        })
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.requestObjects).toBe(0)
+        expect(result.data.url).toContain('&play')
     })
 
     test('completes at 95 percent without overlapping polls', () => {

--- a/spec/torrent_preload.spec.js
+++ b/spec/torrent_preload.spec.js
@@ -1,0 +1,229 @@
+import {readFileSync} from 'node:fs'
+import vm from 'node:vm'
+import {describe, expect, test} from 'vitest'
+
+const source = readFileSync(new URL('../src/interaction/torrent.js', import.meta.url), 'utf8')
+const start = source.indexOf('const TORRENT_PRELOAD_POLL_MS')
+const end = source.indexOf('function list(', start)
+
+if(start < 0 || end < 0) throw new Error('torrent preload implementation not found')
+
+const preloadSource = source.slice(start, end)
+
+class FakeClock {
+    constructor(){
+        this.now = 0
+        this.nextId = 1
+        this.timers = new Map()
+    }
+
+    setTimeout(fn, delay){
+        let id = this.nextId++
+        this.timers.set(id, {at: this.now + Number(delay || 0), fn})
+        return id
+    }
+
+    clearTimeout(id){
+        this.timers.delete(id)
+    }
+
+    advance(ms){
+        let target = this.now + ms
+
+        while(true){
+            let selectedId
+            let selected
+
+            for(let [id, timer] of this.timers){
+                if(timer.at <= target && (!selected || timer.at < selected.at || timer.at === selected.at && id < selectedId)){
+                    selectedId = id
+                    selected = timer
+                }
+            }
+
+            if(!selected) break
+
+            this.timers.delete(selectedId)
+            this.now = selected.at
+            selected.fn()
+        }
+
+        this.now = target
+    }
+}
+
+function harness({android = false, selectedPlayer = 'lampa', gstWork = true, respond} = {}){
+    let clock = new FakeClock()
+    let state = {
+        requests: 0,
+        requestObjects: 0,
+        inFlight: 0,
+        maxInFlight: 0,
+        clears: 0,
+        runs: 0,
+        stops: 0,
+        cancel: null
+    }
+
+    class RequestMock {
+        constructor(){
+            state.requestObjects++
+        }
+
+        timeout(ms){
+            this.timeoutMs = ms
+        }
+
+        silent(url, success, error){
+            let requestIndex = state.requests++
+            state.inFlight++
+            state.maxInFlight = Math.max(state.maxInFlight, state.inFlight)
+
+            let result = respond ? respond(url, requestIndex) : {
+                type: 'success',
+                value: {preloaded_bytes: 95, preload_size: 100}
+            }
+
+            if(result.type === 'hang') return
+
+            clock.setTimeout(()=>{
+                state.inFlight--
+                if(result.type === 'error') error(new Error('network'))
+                else success(result.value)
+            }, result.delay == null ? 5 : result.delay)
+        }
+
+        clear(){
+            state.clears++
+            state.inFlight = 0
+        }
+    }
+
+    class FakeDate extends Date {
+        static now(){
+            return clock.now
+        }
+    }
+
+    let context = {
+        Date: FakeDate,
+        Request: RequestMock,
+        Platform: {is: name=>name === 'android' && android},
+        Storage: {field: name=>name === 'player_torrent' ? selectedPlayer : undefined},
+        Torserver: {
+            ip: ()=>'http://ts',
+            gstWork: ()=>gstWork
+        },
+        Loading: {
+            start: cancel=>state.cancel = cancel,
+            stop: ()=>state.stops++,
+            setProgress: ()=>{}
+        },
+        Utils: {bytesToSize: value=>String(value)},
+        setTimeout: clock.setTimeout.bind(clock),
+        clearTimeout: clock.clearTimeout.bind(clock)
+    }
+
+    vm.runInNewContext(`${preloadSource}\nthis.__preload = preload`, context)
+
+    let data = {
+        url: 'http://ts/stream/file.mkv?index=1&preload',
+        torrent_hash: 'hash'
+    }
+
+    context.__preload(data, ()=>state.runs++)
+
+    return {clock, data, state}
+}
+
+describe('Torrent preload handoff', () => {
+    test('dispatches an external Android torrent immediately through play', () => {
+        let result = harness({android: true, selectedPlayer: 'android', gstWork: false})
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.requestObjects).toBe(0)
+        expect(result.data.url).toContain('&play')
+        expect(result.data.url).not.toContain('&preload')
+    })
+
+    test('completes at 95 percent without overlapping polls', () => {
+        let result = harness({
+            respond: (url, index)=>({
+                type: 'success',
+                value: {preloaded_bytes: index ? 95 : 10, preload_size: 100}
+            })
+        })
+
+        result.clock.advance(1100)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.requests).toBe(2)
+        expect(result.state.maxInFlight).toBe(1)
+    })
+
+    test('falls back to play when progress stalls', () => {
+        let result = harness({
+            respond: ()=>({
+                type: 'success',
+                value: {preloaded_bytes: 0, preload_size: 100}
+            })
+        })
+
+        result.clock.advance(9000)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.maxInFlight).toBe(1)
+        expect(result.data.url).toContain('&play')
+    })
+
+    test('falls back within the stall window after repeated request errors', () => {
+        let result = harness({respond: ()=>({type: 'error'})})
+
+        result.clock.advance(7000)
+        expect(result.state.runs).toBe(0)
+
+        result.clock.advance(2000)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.maxInFlight).toBe(1)
+        expect(result.data.url).toContain('&play')
+    })
+
+    test('uses the independent deadline when a request never calls back', () => {
+        let result = harness({respond: ()=>({type: 'hang'})})
+
+        result.clock.advance(29000)
+        expect(result.state.runs).toBe(0)
+
+        result.clock.advance(2000)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.state.maxInFlight).toBe(1)
+        expect(result.data.url).toContain('&play')
+    })
+
+    test('ignores a late response after the deadline dispatch', () => {
+        let result = harness({
+            respond: ()=>({
+                type: 'success',
+                value: {preloaded_bytes: 95, preload_size: 100},
+                delay: 31000
+            })
+        })
+
+        result.clock.advance(32000)
+
+        expect(result.state.runs).toBe(1)
+        expect(result.data.url).toContain('&play')
+    })
+
+    test('cancels without dispatching playback', () => {
+        let result = harness({respond: ()=>({type: 'hang'})})
+
+        result.state.cancel()
+        result.clock.advance(31000)
+
+        expect(result.state.runs).toBe(0)
+        expect(result.state.stops).toBe(1)
+    })
+})

--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -266,28 +266,96 @@ function parseSubs(path, files){
     return subtitles.length ? subtitles : false
 }
 
+const TORRENT_PRELOAD_POLL_MS = 1000
+const TORRENT_PRELOAD_REQUEST_TIMEOUT_MS = 2000
+const TORRENT_PRELOAD_STALL_MS = 8000
+const TORRENT_PRELOAD_DEADLINE_MS = 30000
+
+function torrentPlayUrl(url){
+    return typeof url === 'string' ? url.replace('&preload', '&play') : url
+}
+
+function isExternalAndroidTorrent(data){
+    return Platform.is('android') && (
+        Storage.field('player_torrent') === 'android' ||
+        data.launch_player === 'android' ||
+        data.torrent_hash && !Torserver.gstWork()
+    )
+}
+
 function preload(data, run){
     let has_server = Torserver.ip() && data.url.indexOf(Torserver.ip()) > -1
     let has_preload = data.url.indexOf('&preload') > -1
     let need_preload = has_server && has_preload
 
+    // An external Android player consumes TorrServer's &play endpoint directly and
+    // performs its own buffering. Holding ACTION_VIEW behind the frontend 95% gate
+    // can otherwise leave the Files screen open forever when peers are slow/stalled.
+    if(need_preload && isExternalAndroidTorrent(data)){
+        data.url = torrentPlayUrl(data.url)
+        run()
+        return
+    }
+
     if(need_preload){
         let checkout
+        let deadline
         let network = new Request()
         let first   = true
+        let finished = false
+        let in_flight = false
+        let last_preloaded = -1
+        let last_progress_at = Date.now()
 
-        Loading.start(()=>{
-            clearInterval(checkout)
-
+        let cleanup = ()=>{
+            clearTimeout(checkout)
+            clearTimeout(deadline)
             network.clear()
-
             Loading.stop()
-        }, '', {media: data})
+        }
 
-        let update = ()=>{    
-            network.timeout(2000)
+        let finish = (fallback)=>{
+            if(finished) return
+            finished = true
+
+            cleanup()
+
+            // A deadline/stall/error fallback must not hand the player the control
+            // endpoint. &play starts the stream while TorrServer keeps buffering.
+            if(fallback) data.url = torrentPlayUrl(data.url)
+
+            run()
+        }
+
+        let cancel = ()=>{
+            if(finished) return
+            finished = true
+            cleanup()
+        }
+
+        Loading.start(cancel, '', {media: data})
+
+        let schedule = ()=>{
+            if(finished) return
+            clearTimeout(checkout)
+            checkout = setTimeout(update, TORRENT_PRELOAD_POLL_MS)
+        }
+
+        let update = ()=>{
+            if(finished || in_flight) return
+
+            if(Date.now() - last_progress_at >= TORRENT_PRELOAD_STALL_MS){
+                finish(true)
+                return
+            }
+
+            in_flight = true
+            network.timeout(TORRENT_PRELOAD_REQUEST_TIMEOUT_MS)
     
             network.silent(first ? data.url : data.url.replace('&preload', '&stat'), function (res) {
+                if(finished) return
+                in_flight = false
+
                 let pb = res.preloaded_bytes || 0,
                     ps = res.preload_size || 0,
                     sp = res.download_speed ? Utils.bytesToSize(res.download_speed * 8, true) : '0.0',
@@ -297,26 +365,35 @@ function preload(data, run){
                 let progress = Math.min(100,((pb * 100) / ps ))
 
                 if(progress >= 95 || isNaN(progress)){
-                    Loading.stop()
-
-                    clearInterval(checkout)
-                    
-                    run()
+                    finish(false)
                 }
                 else{
+                    if(pb > last_preloaded){
+                        last_preloaded = pb
+                        last_progress_at = Date.now()
+                    }
+
                     Loading.setProgress(progress, {
                         speed: sp,
                         active_peers: active_peers,
                         total_peers: total_peers
                     })
+
+                    schedule()
                 }
+            }, function () {
+                if(finished) return
+                in_flight = false
+                schedule()
             })
 
             first = false
         }
-    
-        checkout = setInterval(update,1000)
-    
+
+        // Independent of request callbacks: even a request implementation that never
+        // reports timeout/error cannot keep this gate alive without bound.
+        deadline = setTimeout(()=>finish(true), TORRENT_PRELOAD_DEADLINE_MS)
+
         update()
     }
     else run()

--- a/src/interaction/torrent.js
+++ b/src/interaction/torrent.js
@@ -276,11 +276,16 @@ function torrentPlayUrl(url){
 }
 
 function isExternalAndroidTorrent(data){
-    return Platform.is('android') && (
-        Storage.field('player_torrent') === 'android' ||
-        data.launch_player === 'android' ||
+    if(!Platform.is('android')) return false
+
+    // A one-shot player selected from the file context menu must win over the
+    // persisted default. Player.runas() keeps that choice private to player.js,
+    // so torrent.js also carries it on the media item until Player.play().
+    if(data.launch_player === 'lampa' || data.launch_player === 'inner') return false
+    if(data.launch_player === 'android') return true
+
+    return Storage.field('player_torrent') === 'android' ||
         data.torrent_hash && !Torserver.gstWork()
-    )
 }
 
 function preload(data, run){
@@ -665,6 +670,8 @@ function list(items, params){
                     Controller.toggle(enabled)
 
                     if(a.player){
+                        element.launch_player = a.player
+
                         Player.runas(a.player)
 
                         item.trigger('hover:enter')


### PR DESCRIPTION
Fixes the torrent Files screen waiting indefinitely behind the 95% frontend preload gate. External Android torrent playback is handed directly to TorrServer's &play endpoint; other players keep the existing preload UI with sequential polling, request timeout, stall fallback, hard deadline, idempotent cleanup, and no overlapping requests. No templates, settings, UX layout, or Android/APK code are changed. Tests: full Vitest 61/61; 7 preload regression cases; syntax and diff checks pass.